### PR TITLE
Add node to track Hubitat hub mode

### DIFF
--- a/nodes/config.js
+++ b/nodes/config.js
@@ -22,6 +22,23 @@ module.exports = function(RED) {
       return;
     }
 
+    node.getMode = async function() {
+      const url = `${node.baseUrl}/modes?access_token=${node.token}`;
+      const options = {method: 'GET'};
+      try {
+        const response = await fetch(url, options);
+        var mode = await response.json();
+      }
+      catch(err) {
+        console.log(err);
+        console.log("unable to fetch modes.");
+      }
+
+      console.log("HubitatConfigNode: Mode:");
+      console.log(mode);
+      return mode;
+    };
+
     node.getDevice = async function(deviceId, type) {
       const url = `${node.baseUrl}/devices/${deviceId}?access_token=${node.token}`;
       const options = {method: 'GET'};
@@ -132,7 +149,11 @@ module.exports = function(RED) {
       return;
     }
 
-    const callback = callbacks[req.body.content["deviceId"]];
+    if(req.body.content["deviceId"] != null) {
+      var callback = callbacks[req.body.content["deviceId"]];
+    } else if (req.body.content["deviceId"] == null && req.body.content["name"] == "mode") {
+      var callback = callbacks[0];
+    }
 
     if(callback){
       callback.forEach( (c) => {

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -151,7 +151,7 @@ module.exports = function(RED) {
 
     if(req.body.content["deviceId"] != null) {
       var callback = callbacks[req.body.content["deviceId"]];
-    } else if (req.body.content["deviceId"] == null && req.body.content["name"] == "mode") {
+    } else if (req.body.content["name"] == "mode") {
       var callback = callbacks[0];
     }
 

--- a/nodes/mode.html
+++ b/nodes/mode.html
@@ -43,30 +43,30 @@
 </script>
 
 <script type="text/html" data-help-name="hubitat mode">
-  <p>A node that keeps the current mode of your Hubitat hub.</p>
+  <p>A node that stores and can send the current mode of your Hubitat hub.</p>
 
   <h3>Inputs</h3>
-    <p>Any input will force the node to output the current mode in the payload.</p>
+    <p>Any input will cause the node to update itself with the current mode from the hub.</p>
 
   <h3>Output</h3>
     <dl class="message-properties">
-      <dt class="optional">payload <span class="property-type">string</span></dt>
-      <dd>The attribute values. example:
-        <code>
-          {
-              payload: {
-                  name: "mode",
-                  value: "Day",
-                  displayName: "My Home",
-                  descriptionText: "My Home is now in Day mode"
-              }
-          }
-      </code>
+      <dt class="optional">payload <span class="property-type">object</span></dt>
+      <dd>Information about the current hub mode.
+        <br>
+        <p><strong>Note:</strong> The <code>displayName</code> and <code>descriptionText</code> fields are sent only when the hub generates a mode event.  If this node is used to request the current hub mode, these fields are omitted.</p>
+        <p>Example:</p>
+<pre>payload: {
+    name: "mode",
+    value: "Day",
+    displayName: "My Home",
+    descriptionText: "My Home is now in Day mode"
+}</pre>
       </dd>
     </dl>
 
   <h3>Details</h3>
-    <p>This node will store the current hub mode. Every time the mode changes at Hubitat, the webhook will send us the current status.</p>
-    <p><b>Send events</b> allow to send or not event when it receive one from Hubitat.</p>
+    <p>This node will store the current hub mode. When a mode change occurs at the hub, the Maker API app sends the event to Node-RED via HTTP POST.</p>
+    <p>This node requires that you have enabled the "Include location events to be sent by POST?" option in the Maker API app and that the URL be configured to point to <code>/hubitat/webhook</code> on your Node-RED server.</p>
+    <p><b>Send events:</b> Enables output of this node as described above.</p>
     <p>This node is not compatible with Node-RED 0.x</p>
 </script>

--- a/nodes/mode.html
+++ b/nodes/mode.html
@@ -1,0 +1,72 @@
+<script type="text/javascript">
+  RED.nodes.registerType('hubitat mode',{
+    category: 'hubitat',
+    color: '#a6bbcf',
+    defaults: {
+      name: {value:""},
+      server: {type: "hubitat config", required: true},
+      sendEvent: {value: true},
+    },
+    inputs:1,
+    outputs:1,
+    icon: "icons/hubitat.png",
+    label: function() {
+        return this.name || "mode";
+    },
+    paletteLabel: "mode",
+    oneditprepare: function() {
+      $("document").ready(() => {
+        $('#node-input-server').change(() => {
+          const serverId = $('#node-input-server option:selected').val();
+          server = RED.nodes.node(serverId);
+        });
+      });
+    }
+  });
+
+
+</script>
+
+<script type="text/html" data-template-name="hubitat mode">
+  <div class="form-row">
+    <label for="node-input-server"><i class="fa fa-globe"></i> Server</label>
+    <input type="text" id="node-input-server">
+  </div>
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+  <div class="form-row">
+    <label for="node-input-sendEvent" style="width: auto"><i class="fa fa-rocket"></i> Send events </label>
+    <input type="checkbox" id="node-input-sendEvent" style="display: inline-block; width: auto; vertical-align: top;" checked>
+  </div>
+</script>
+
+<script type="text/html" data-help-name="hubitat mode">
+  <p>A node that keeps the current mode of your Hubitat hub.</p>
+
+  <h3>Inputs</h3>
+    <p>Any input will force the node to output the current mode in the payload.</p>
+
+  <h3>Output</h3>
+    <dl class="message-properties">
+      <dt class="optional">payload <span class="property-type">string</span></dt>
+      <dd>The attribute values. example:
+        <code>
+          {
+              payload: {
+                  name: "mode",
+                  value: "Day",
+                  displayName: "My Home",
+                  descriptionText: "My Home is now in Day mode"
+              }
+          }
+      </code>
+      </dd>
+    </dl>
+
+  <h3>Details</h3>
+    <p>This node will store the current hub mode. Every time the mode changes at Hubitat, the webhook will send us the current status.</p>
+    <p><b>Send events</b> allow to send or not event when it receive one from Hubitat.</p>
+    <p>This node is not compatible with Node-RED 0.x</p>
+</script>

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -1,0 +1,88 @@
+module.exports = function(RED) {
+  const fetch = require('node-fetch');
+
+  function castHubitatValue(dataType, value) {
+    switch(dataType) {
+      case "STRING":
+        return value;
+      case "ENUM":
+        return value;
+      case "NUMBER":
+        return parseFloat(value);
+      case "BOOL":
+        return value == "true";
+      default:
+        console.warn("Unable to cast to dataType. Open an issue to report back the following output:");
+        console.warn(dataType);
+        console.warn(value);
+        return value;
+    }
+  }
+
+  function HubitatModeNode(config) {
+    RED.nodes.createNode(this, config);
+
+    this.hubitat = RED.nodes.getNode(config.server);
+    this.name = config.name;
+    this.sendEvent = config.sendEvent;
+    this.currentMode = undefined;
+    this.deviceId = 0;
+
+    let node = this;
+
+    if (!node.hubitat) {
+      console.log("HubitatModeNode: Hubitat server not configured");
+      return;
+    }
+
+    const callback = (event) => {
+      console.debug("Mode(" + node.name + "): Callback called");
+      console.debug(event);
+      if (this.currentMode === undefined) {
+        node.status({fill:"red", shape:"dot", text:"Uninitialized"});
+        console.warn("Mode(" + node.name + "): Uninitialized");
+        return;
+      }
+
+      if (this.sendEvent) {
+        this.send({payload: event});
+      }
+
+      this.currentMode = event["value"];
+      node.status({fill:"blue", shape:"dot", text: this.currentMode});
+    }
+
+    node.hubitat.registerCallback(node, node.deviceId, callback);
+
+    node.hubitat.getMode().then( (mode) => {
+      node.currentMode = mode.filter(function(eachMode) {
+        return eachMode.active;
+      })[0].name;
+      console.debug("Mode(" + node.name + "): Status refreshed.  Current mode: " + node.currentMode);
+      node.status({fill:"blue", shape:"dot", text:node.currentMode});
+    }).catch( err => {
+      console.log(err);
+      node.status({fill:"red", shape:"dot", text:"Uninitialized"});
+    });
+
+
+    node.on('input', function(msg, send, done) {
+      console.debug("HubitatModeNode: Input received");
+      console.debug(msg);
+
+      msg.payload = {};
+      msg.payload["name"] = "mode";
+      msg.payload["value"] = node.currentMode;
+      send(msg);
+
+      done();
+    });
+
+    node.on('close', function() {
+      console.debug("HubitatModeNode: Closed");
+      node.hubitat.unregisterCallback(node, callback);
+    });
+  }
+
+  RED.nodes.registerType("hubitat mode", HubitatModeNode);
+}

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -1,24 +1,6 @@
 module.exports = function(RED) {
   const fetch = require('node-fetch');
 
-  function castHubitatValue(dataType, value) {
-    switch(dataType) {
-      case "STRING":
-        return value;
-      case "ENUM":
-        return value;
-      case "NUMBER":
-        return parseFloat(value);
-      case "BOOL":
-        return value == "true";
-      default:
-        console.warn("Unable to cast to dataType. Open an issue to report back the following output:");
-        console.warn(dataType);
-        console.warn(value);
-        return value;
-    }
-  }
-
   function HubitatModeNode(config) {
     RED.nodes.createNode(this, config);
 
@@ -44,11 +26,18 @@ module.exports = function(RED) {
         return;
       }
 
+      this.currentMode = event["value"];
+
+      outgoingEvent = {};
+      outgoingEvent["name"] = "mode";
+      outgoingEvent["value"] = node.currentMode;
+      outgoingEvent["displayName"] = event["displayName"];
+      outgoingEvent["descriptionText"] = event["descriptionText"];
+
       if (this.sendEvent) {
-        this.send({payload: event});
+        this.send({payload: outgoingEvent});
       }
 
-      this.currentMode = event["value"];
       node.status({fill:"blue", shape:"dot", text: this.currentMode});
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-hubitat",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Node Red module for Hubitat API",
   "main": "index.js",
   "scripts": {
@@ -27,7 +27,8 @@
     "nodes": {
       "command": "nodes/command.js",
       "config": "nodes/config.js",
-      "device": "nodes/device.js"
+      "device": "nodes/device.js",
+      "mode": "nodes/mode.js"
     }
   }
 }


### PR DESCRIPTION
I registered the mode callback with a deviceId of 0 to fit it in with the way you've been doing the callback lookups.  It's a bit of a hack, but should be safe from any ID collisions.