### PR TITLE
Multi Hub support, include deviceId in message and set msg.topic

### DIFF
--- a/nodes/config.html
+++ b/nodes/config.html
@@ -8,6 +8,7 @@
       port: {value: 80, required: true, validate: RED.validators.number()},
       token: {value: "", required: true},
       appId: {value: "", required: true, validate: RED.validators.number()},
+      webhook: {value: "/hubitat/webhook", required: false},
     },
     label: function() {
       if (this.name) {
@@ -38,6 +39,12 @@
         id: "hubitat-config-tab-security",
         label: "Security"
       });
+
+      tabs.addTab({
+        id: "hubitat-config-tab-advanced",
+        label: "Advanced"
+      });
+
     }
   });
 </script>
@@ -73,6 +80,13 @@
         <input type="text" id="node-config-input-token" placeholder="00000000-0000-4000-8000-000000000000">
       </div>
     </div>
+    <div id="hubitat-config-tab-advanced" style="display:none">
+      <div class="form-row">
+        <label for="node-config-input-webhook"><i class="fa fa-gear"></i> Webhook URL</label>
+        <input type="text" id="node-config-input-webhook" placeholder="/hubitat/webhook">
+      </div>
+    </div>
+
   </div>
 </script>
 

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -88,8 +88,8 @@ module.exports = function(RED) {
     
     if (RED.settings.httpNodeRoot !== false) {
         if (!this.webhook) {
-            this.warn(RED._("webhook url not set"));
-            return;
+            this.warn(RED._("webhook url not set, set default to /hubitat/webhook"));
+	    this.webhook = "/hubitat/webhook";
         }
         if (this.webhook[0] !== '/') {
             this.webhook = '/'+this.webhook;
@@ -119,8 +119,6 @@ module.exports = function(RED) {
                     c.callback.call(c.parent, req.body.content);
                 });
             }
-
-            //DO THE CALLBACK HERE FROM BELOW
         };
         var httpMiddleware = function(req,res,next) { next(); }
         var corsHandler = function(req,res,next) { next(); }

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -1,8 +1,11 @@
 module.exports = function(RED) {
   const fetch = require('node-fetch');
 
+    var bodyParser = require("body-parser");
+    var cookieParser = require("cookie-parser");
+
   let nodes = {};
-  let callbacks = [];
+//  let callbacks = [];
 
   function HubitatConfigNode(config) {
     RED.nodes.createNode(this,config);
@@ -12,6 +15,8 @@ module.exports = function(RED) {
     this.port = config.port;
     this.token = config.token;
     this.appId = config.appId;
+    this.webhook = config.webhook;
+    this.callbacks = [];
 
     const scheme = ((this.usetls) ? 'https': 'http');
     this.baseUrl = `${scheme}://${this.host}:${this.port}/apps/api/${this.appId}`;
@@ -61,26 +66,80 @@ module.exports = function(RED) {
     };
 
     node.unregisterCallback = function(parent, deviceId, callback) {
-      if (callbacks[deviceId]) {
-        callbacks[deviceId] = callbacks[deviceId].filter( (c) => c.callback !== callback );
-        if (callbacks[deviceId].length  == 0) {
-          delete callbacks[deviceId];
+      if (node.callbacks[deviceId]) {
+        node.callbacks[deviceId] = node.callbacks[deviceId].filter( (c) => c.callback !== callback );
+        if (node.callbacks[deviceId].length  == 0) {
+          delete node.callbacks[deviceId];
         }
       }
     };
 
     node.registerCallback = function(parent, deviceId, callback) {
-      if (!(deviceId in callbacks)) {
-        callbacks[deviceId] = [];
+      if (!(deviceId in node.callbacks)) {
+        node.callbacks[deviceId] = [];
       }
 
-      callbacks[deviceId].push({
+      node.callbacks[deviceId].push({
         parent: parent,
         callback: callback
       });
     };
-
     nodes[node.baseUrl] = node;
+    
+    if (RED.settings.httpNodeRoot !== false) {
+        if (!this.webhook) {
+            this.warn(RED._("webhook url not set"));
+            return;
+        }
+        if (this.webhook[0] !== '/') {
+            this.webhook = '/'+this.webhook;
+        }
+        console.log('Starting endpoint for ' + this.webhook);
+        this.webErrorHandler = function(err,req,res,next) {
+            node.warn(err);
+            res.sendStatus(500);
+        };
+        this.postCallback = function(req,res) {
+            var msgid = RED.util.generateId();
+            res._msgid = msgid;
+            console.log(req.body);
+            if (!req.body.content) {
+                node.warn('no content in body');
+                return;
+            }
+
+            if(req.body.content["deviceId"] != null) {
+                var callback = node.callbacks[req.body.content["deviceId"]];
+            } else if (req.body.content["name"] == "mode") {
+                var callback = node.callbacks[0];
+            }
+
+            if(callback){
+                callback.forEach( (c) => {
+                    c.callback.call(c.parent, req.body.content);
+                });
+            }
+
+            //DO THE CALLBACK HERE FROM BELOW
+        };
+        var httpMiddleware = function(req,res,next) { next(); }
+        var corsHandler = function(req,res,next) { next(); }
+        var maxApiRequestSize = RED.settings.apiMaxLength || '5mb';
+        var jsonParser = bodyParser.json({limit:maxApiRequestSize});
+        var urlencParser = bodyParser.urlencoded({limit:maxApiRequestSize,extended:true});
+        var metricsHandler = function(req,res,next) { next(); }
+        var multipartParser = function(req,res,next) { next(); }
+        var rawBodyParser = function(req, res, next) {next(); }
+        RED.httpNode.post(this.webhook,cookieParser(),httpMiddleware,corsHandler,metricsHandler,jsonParser,urlencParser,multipartParser,rawBodyParser,this.postCallback,this.webErrorHandler);
+        this.on("close",function() {
+            var node = this;
+            RED.httpNode._router.stack.forEach(function(route,i,routes) {
+                if (route.route && route.route.path === node.url && route.route.methods[node.method]) {
+                    routes.splice(i,1);
+                }
+            });
+        });
+    }
   }
 
   RED.nodes.registerType("hubitat config", HubitatConfigNode);
@@ -138,30 +197,6 @@ module.exports = function(RED) {
       console.log(err);
       res.send(err);
     }
-  });
-
-  RED.httpAdmin.post('/hubitat/webhook', function(req,res){
-
-    console.log("POST /hubitat/webhook with body:");
-    console.log(req.body);
-    if (!req.body.content) {
-      res.sendStatus(400);
-      return;
-    }
-
-    if(req.body.content["deviceId"] != null) {
-      var callback = callbacks[req.body.content["deviceId"]];
-    } else if (req.body.content["name"] == "mode") {
-      var callback = callbacks[0];
-    }
-
-    if(callback){
-      callback.forEach( (c) => {
-        c.callback.call(c.parent, req.body.content);
-      });
-    }
-
-    res.sendStatus(204);
   });
 
 }

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -48,6 +48,8 @@ module.exports = function(RED) {
       this.currentAttributes.forEach( (attribute) => {
         if (event["name"] === attribute["name"]) {
           attribute["currentValue"] = castHubitatValue(attribute["dataType"], event["value"]);
+	  attribute["deviceName"] = node.name;
+	  attribute["deviceId"] = node.deviceId;
           node.status({});
           if (this.sendEvent) {
             this.send({payload: attribute});

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -48,11 +48,10 @@ module.exports = function(RED) {
       this.currentAttributes.forEach( (attribute) => {
         if (event["name"] === attribute["name"]) {
           attribute["currentValue"] = castHubitatValue(attribute["dataType"], event["value"]);
-	  attribute["deviceName"] = node.name;
-	  attribute["deviceId"] = node.deviceId;
+	      attribute["deviceId"] = node.deviceId;
           node.status({});
           if (this.sendEvent) {
-            this.send({payload: attribute});
+            this.send({payload: attribute, topic: node.name});
           }
           found = true;
         }

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -34,7 +34,7 @@ module.exports = function(RED) {
       };
 
       if (this.sendEvent) {
-        this.send({payload: outgoingEvent});
+        this.send({payload: outgoingEvent, topic: "hubitat-mode"});
       }
 
       node.status({fill:"blue", shape:"dot", text: this.currentMode});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "author": "Francois Blackburn",
   "license": "MIT",
   "dependencies": {
+    "cookie-parse": "^0.4.0",
+    "cookie-parser": "^1.4.4",
     "node-fetch": "^2.6.0"
   },
   "keywords": [


### PR DESCRIPTION
1. enhancements to support multiple hubs with specifying different post endpoints per config 
2. adding the deviceId to the sendEvent message
3. setting msg.topic to the device name or to "hubitat-mode" for mode updates. 