### PR TITLE
use events instead of callbacks to avoid fake deviceIDs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,3 @@ To run linter:
 To run unit tests:
 
   * `mocha test/nodes/*_spec.js`
-
-## Thanks
-
-To [node-red-contrib-smartthings](https://github.com/otaviojr/node-red-contrib-smartthings) for the webhook logic

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -117,10 +117,11 @@ module.exports = function HubitatConfigModule(RED) {
           return;
         }
 
-        if (req.body.content.deviceId != null) {
-          node.hubitatEvent.emit('device', req.body.content);
-        } else if (req.body.content.name === 'mode') {
-          node.hubitatEvent.emit('mode', req.body.content);
+        const { content } = req.body;
+        if (content.deviceId != null) {
+          node.hubitatEvent.emit(`device.${content.deviceId}`, content);
+        } else if (content.name === 'mode') {
+          node.hubitatEvent.emit('mode', content);
         }
 
         res.sendStatus(204);

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -4,7 +4,7 @@ module.exports = function HubitatConfigModule(RED) {
   const fetch = require('node-fetch');
   const bodyParser = require('body-parser');
   const cookieParser = require('cookie-parser');
-  const events = require("events");
+  const events = require('events');
 
   const nodes = {};
   let requestPool = 4; // 4 simultaneous requests seem to never cause issue
@@ -39,7 +39,7 @@ module.exports = function HubitatConfigModule(RED) {
     this.nodeRedServer = config.nodeRedServer;
     this.webhookPath = config.webhookPath;
     this.hubitatEvent = new events.EventEmitter();
-    
+
     const scheme = ((this.usetls) ? 'https' : 'http');
     this.baseUrl = `${scheme}://${this.host}:${this.port}/apps/api/${this.appId}`;
 
@@ -48,7 +48,7 @@ module.exports = function HubitatConfigModule(RED) {
     if ((!node.host) || (!node.port) || (!node.token) || (!node.appId)) {
       return;
     }
-    
+
     node.getMode = async () => {
       const url = `${node.baseUrl}/modes?access_token=${node.token}`;
       const options = { method: 'GET' };
@@ -117,7 +117,6 @@ module.exports = function HubitatConfigModule(RED) {
           return;
         }
 
-        let callback;
         if (req.body.content.deviceId != null) {
           node.hubitatEvent.emit('device', req.body.content);
         } else if (req.body.content.name === 'mode') {

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -57,44 +57,44 @@ module.exports = function HubitatDeviceModule(RED) {
       });
     }
 
-    const callback = async function callback(event) {
-      node.debug(`Callback called: ${JSON.stringify(event)}`);
-      if (this.currentAttributes === undefined) {
-        try {
-          await initializeDevice();
-        } catch (err) {
-          return;
-        }
-      }
-
-      let found = false;
-      this.currentAttributes.forEach((attribute) => {
-        if (event.name === attribute.name) {
-          attribute.value = castHubitatValue(node, attribute.dataType, event.value);
-          attribute.deviceId = this.deviceId;
-          attribute.currentValue = attribute.value; // deprecated since 0.0.18
-
-          if ((this.attribute === event.name) || (!this.attribute)) {
-            if (this.attribute) {
-              this.status({ fill: 'blue', shape: 'dot', text: `${this.attribute}: ${attribute.value}` });
-              node.log(`${node.attribute}: ${attribute.value}`);
-            } else {
-              this.status({});
-              node.log('Attributes refreshed');
+    this.hubitat.hubitatEvent.on('device', (async function (node, event) {
+        if (node.deviceId && node.deviceId === event.deviceId) {
+            node.debug(`Callback called: ${JSON.stringify(event)}`);
+            if (node.currentAttributes === undefined) {
+                try {
+                    await initializeDevice();
+                } catch (err) {
+                    return;
+                }
             }
-            if (this.sendEvent) {
-              this.send({ payload: attribute, topic: this.name });
-            }
-          }
-          found = true;
-        }
-      });
 
-      if (!found) {
-        this.status({ fill: 'red', shape: 'dot', text: `Unknown event: ${event.name}` });
-      }
-    };
-    node.hubitat.registerCallback(node, node.deviceId, callback);
+            let found = false;
+            node.currentAttributes.forEach((attribute) => {
+              if (event.name === attribute.name) {
+                attribute.value = castHubitatValue(node, attribute.dataType, event.value);
+                attribute.deviceId = this.deviceId;
+                attribute.currentValue = attribute.value; // deprecated since 0.0.18
+
+                if ((node.attribute === event.name) || (!node.attribute)) {
+                  if (node.attribute) {
+                    node.status({ fill: 'blue', shape: 'dot', text: `${node.attribute}: ${attribute.value}` });
+                    node.log(`${node.attribute}: ${attribute.value}`);
+                  } else {
+                    node.status({});
+                    node.log('Attributes refreshed');
+                  }
+                  if (node.sendEvent) {
+                    node.send({ payload: attribute, topic: node.name });
+                  }
+                }
+                found = true;
+              }
+            });
+            if (!found) {
+              node.status({ fill: 'red', shape: 'dot', text: `Unknown event: ${event.name}` });
+            }
+        }
+    }).bind(null, this)); 
 
     initializeDevice().catch(() => {});
 
@@ -135,7 +135,6 @@ module.exports = function HubitatDeviceModule(RED) {
 
     node.on('close', () => {
       node.debug('Closed');
-      node.hubitat.unregisterCallback(node, node.deviceId, callback);
     });
   }
 

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -57,10 +57,7 @@ module.exports = function HubitatDeviceModule(RED) {
       });
     }
 
-    this.hubitat.hubitatEvent.on('device', async (event) => {
-      if (!node.deviceId || node.deviceId !== event.deviceId) {
-        return;
-      }
+    this.hubitat.hubitatEvent.on(`device.${node.deviceId}`, async (event) => {
       node.debug(`Callback called: ${JSON.stringify(event)}`);
       if (node.currentAttributes === undefined) {
         try {

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -57,7 +57,7 @@ module.exports = function HubitatDeviceModule(RED) {
       });
     }
 
-    this.hubitat.hubitatEvent.on('device', (async (node, event) => {
+    this.hubitat.hubitatEvent.on('device', async (event) => {
       if (!node.deviceId || node.deviceId !== event.deviceId) {
         return;
       }
@@ -95,7 +95,7 @@ module.exports = function HubitatDeviceModule(RED) {
       if (!found) {
         node.status({ fill: 'red', shape: 'dot', text: `Unknown event: ${event.name}` });
       }
-    }).bind(null, this));
+    });
 
     initializeDevice().catch(() => {});
 

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -74,7 +74,7 @@ module.exports = function HubitatDeviceModule(RED) {
       node.currentAttributes.forEach((attribute) => {
         if (event.name === attribute.name) {
           attribute.value = castHubitatValue(node, attribute.dataType, event.value);
-          attribute.deviceId = this.deviceId;
+          attribute.deviceId = node.deviceId;
           attribute.currentValue = attribute.value; // deprecated since 0.0.18
 
           if ((node.attribute === event.name) || (!node.attribute)) {

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -25,7 +25,7 @@ module.exports = function HubitatModeModule(RED) {
         throw err;
       });
     }
-    this.hubitat.hubitatEvent.on('mode', (async function (node, event) {
+    this.hubitat.hubitatEvent.on('mode', (async (node, event) => {
       node.debug(`Callback called: ${JSON.stringify(event)}`);
       node.currentMode = event.value;
       node.log(`Mode: ${this.currentMode}`);

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -25,7 +25,7 @@ module.exports = function HubitatModeModule(RED) {
         throw err;
       });
     }
-    this.hubitat.hubitatEvent.on('mode', (async (node, event) => {
+    this.hubitat.hubitatEvent.on('mode', async (event) => {
       node.debug(`Callback called: ${JSON.stringify(event)}`);
       node.currentMode = event.value;
       node.log(`Mode: ${node.currentMode}`);
@@ -44,7 +44,7 @@ module.exports = function HubitatModeModule(RED) {
       }
 
       node.status({ fill: 'blue', shape: 'dot', text: node.currentMode });
-    }).bind(null, this));
+    });
 
     initializeMode().catch(() => {});
 

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -28,13 +28,13 @@ module.exports = function HubitatModeModule(RED) {
     this.hubitat.hubitatEvent.on('mode', (async (node, event) => {
       node.debug(`Callback called: ${JSON.stringify(event)}`);
       node.currentMode = event.value;
-      node.log(`Mode: ${this.currentMode}`);
+      node.log(`Mode: ${node.currentMode}`);
 
       if (node.sendEvent) {
         const msg = {
           payload: {
             name: 'mode',
-            value: this.currentMode,
+            value: node.currentMode,
             displayName: event.displayName,
             descriptionText: event.descriptionText,
           },
@@ -43,7 +43,7 @@ module.exports = function HubitatModeModule(RED) {
         node.send(msg);
       }
 
-      node.status({ fill: 'blue', shape: 'dot', text: this.currentMode });
+      node.status({ fill: 'blue', shape: 'dot', text: node.currentMode });
     }).bind(null, this));
 
     initializeMode().catch(() => {});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "node-fetch": "^2.6.0",
     "node-red": "^1.0.4",
     "should": "^13.2.3",
+    "events": "^3.0.0",
     "sinon": "^1.17.7"
   },
   "keywords": [

--- a/test/nodes/device_spec.js
+++ b/test/nodes/device_spec.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-unused-vars */
+const helper = require('node-red-node-test-helper');
+const deviceNode = require('../../nodes/device.js');
+
+
+describe('Hubitat Device Node', () => {
+  const defaultDeviceNode = {
+    id: 'n1',
+    type: 'hubitat device',
+    name: 'test device name',
+    server: 'n0',
+    deviceId: '42',
+    attribute: 'testAttribute',
+    sendEvent: true,
+  };
+
+  afterEach(() => {
+    helper.unload();
+  });
+
+  it('should be loaded', (done) => {
+    const flow = [defaultDeviceNode];
+    helper.load(deviceNode, flow, () => {
+      const n1 = helper.getNode('n1');
+      try {
+        n1.should.have.property('name', 'test device name');
+        n1.should.have.property('deviceId', '42');
+        n1.should.have.property('sendEvent', true);
+        n1.should.have.property('attribute', 'testAttribute');
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+});

--- a/test/nodes/device_spec.js
+++ b/test/nodes/device_spec.js
@@ -1,9 +1,21 @@
 /* eslint-disable no-unused-vars */
 const helper = require('node-red-node-test-helper');
+const configNode = require('../../nodes/config.js');
 const deviceNode = require('../../nodes/device.js');
 
-
 describe('Hubitat Device Node', () => {
+  const defaultConfigNode = {
+    id: 'n0',
+    type: 'hubitat config',
+    name: 'test config name',
+    usetls: false,
+    host: 'localhost',
+    port: 10234,
+    token: '1234-abcd',
+    appId: 1,
+    nodeRedServer: 'localhost',
+    webhookPath: '/hubitat/webhook',
+  };
   const defaultDeviceNode = {
     id: 'n1',
     type: 'hubitat device',
@@ -31,6 +43,33 @@ describe('Hubitat Device Node', () => {
       } catch (err) {
         done(err);
       }
+    });
+  });
+  it('should send event when event received', (done) => {
+    const flow = [
+      defaultConfigNode,
+      { ...defaultDeviceNode, wires: [['n2']] },
+      { id: 'n2', type: 'helper' },
+    ];
+    const hubitatEvent = {
+      deviceId: '42',
+      name: 'testAttribute',
+      value: 'new-value',
+    };
+    helper.load([deviceNode, configNode], flow, () => {
+      const n0 = helper.getNode('n0');
+      const n1 = helper.getNode('n1');
+      const n2 = helper.getNode('n2');
+      n1.currentAttributes = [{ name: 'testAttribute', value: 'old-value' }];
+      n2.on('input', (msg) => {
+        try {
+          msg.should.have.property('payload', { ...hubitatEvent, currentValue: hubitatEvent.value });
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      n0.hubitatEvent.emit('device', hubitatEvent);
     });
   });
 });

--- a/test/nodes/device_spec.js
+++ b/test/nodes/device_spec.js
@@ -69,7 +69,7 @@ describe('Hubitat Device Node', () => {
           done(err);
         }
       });
-      n0.hubitatEvent.emit('device', hubitatEvent);
+      n0.hubitatEvent.emit('device.42', hubitatEvent);
     });
   });
   it('should not send event when event received with wrong deviceId', (done) => {
@@ -92,7 +92,7 @@ describe('Hubitat Device Node', () => {
       n2.on('input', (msg) => {
         inError = true;
       });
-      n0.hubitatEvent.emit('device', hubitatEvent);
+      n0.hubitatEvent.emit('device.999', hubitatEvent);
       setTimeout(() => {
         if (inError) {
           done(new Error('device receive wrong event'));

--- a/test/nodes/mode_spec.js
+++ b/test/nodes/mode_spec.js
@@ -1,0 +1,30 @@
+const helper = require('node-red-node-test-helper');
+const modeNode = require('../../nodes/mode.js');
+
+describe('Hubitat Mode Node', () => {
+  const defaultModeNode = {
+    id: 'n1',
+    type: 'hubitat mode',
+    name: 'test mode name',
+    server: 'n0',
+    sendEvent: true,
+  };
+
+  afterEach(() => {
+    helper.unload();
+  });
+
+  it('should be loaded', (done) => {
+    const flow = [defaultModeNode];
+    helper.load(modeNode, flow, () => {
+      const n1 = helper.getNode('n1');
+      try {
+        n1.should.have.property('name', 'test mode name');
+        n1.should.have.property('sendEvent', true);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+  });
+});

--- a/test/nodes/mode_spec.js
+++ b/test/nodes/mode_spec.js
@@ -1,7 +1,20 @@
 const helper = require('node-red-node-test-helper');
+const configNode = require('../../nodes/config.js');
 const modeNode = require('../../nodes/mode.js');
 
 describe('Hubitat Mode Node', () => {
+  const defaultConfigNode = {
+    id: 'n0',
+    type: 'hubitat config',
+    name: 'test config name',
+    usetls: false,
+    host: 'localhost',
+    port: 10234,
+    token: '1234-abcd',
+    appId: 1,
+    nodeRedServer: 'localhost',
+    webhookPath: '/hubitat/webhook',
+  };
   const defaultModeNode = {
     id: 'n1',
     type: 'hubitat mode',
@@ -25,6 +38,34 @@ describe('Hubitat Mode Node', () => {
       } catch (err) {
         done(err);
       }
+    });
+  });
+  it('should send event when event received', (done) => {
+    const flow = [
+      defaultConfigNode,
+      { ...defaultModeNode, wires: [['n2']] },
+      { id: 'n2', type: 'helper' },
+    ];
+    const hubitatEvent = {
+      name: 'mode',
+      value: 'new-value',
+      displayName: 'My Hub',
+      descriptionText: 'New Value',
+    };
+    helper.load([modeNode, configNode], flow, () => {
+      const n0 = helper.getNode('n0');
+      const n1 = helper.getNode('n1');
+      const n2 = helper.getNode('n2');
+      n1.currentMode = 'old-value';
+      n2.on('input', (msg) => {
+        try {
+          msg.should.have.property('payload', hubitatEvent);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      n0.hubitatEvent.emit('mode', hubitatEvent);
     });
   });
 });


### PR DESCRIPTION
This is the base and should be looked at first as the other PRs will rely on it