### PR TITLE
mode-setter: allow to override mode with mode name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.0.30
 
+* `mode-setter` node: allow to override mode with the mode name (e.i. msg.mode = 'Away')
 * `device` node: fix behavior that other nodes can change it internal properties
 * add support for `DATE` dataType
 

--- a/nodes/mode-setter.html
+++ b/nodes/mode-setter.html
@@ -84,8 +84,12 @@
 
   <h3>Inputs</h3>
     <dl class="message-properties">
+      <dt class="optional">mode <span class="property-type">string</span></dt>
+      <dd>Allow to overwrite the mode set. The value must be the exact mode name</dd>
+    </dl>
+    <dl class="message-properties">
       <dt class="optional">modeId <span class="property-type">string</span></dt>
-      <dd>Allow to overwrite the mode set. Warning: it MUST be the mode ID, not name</dd>
+      <dd>Allow to overwrite the mode set. The value must be the mode ID</dd>
     </dl>
 
   <h3>Output</h3>

--- a/nodes/mode-setter.js
+++ b/nodes/mode-setter.js
@@ -8,17 +8,46 @@ module.exports = function HubitatModeSetterModule(RED) {
     this.hubitat = RED.nodes.getNode(config.server);
     this.name = config.name;
     this.modeId = config.modeId;
+    this.availableModes = {};
     const node = this;
 
     if (!node.hubitat) {
       node.error('Hubitat server not configured');
       return;
     }
+    async function fetchAvailableModes() {
+      return node.hubitat.getMode().then((mode) => {
+        if (!mode) { throw new Error(JSON.stringify(mode)); }
+        node.availableModes = mode.reduce((accumulator, value) => {
+          accumulator[value.name] = value.id;
+          return accumulator;
+        }, {});
+      }).catch((err) => {
+        node.warn(`Unable to fetch available modes: ${err.message}`);
+        node.status({ fill: 'red', shape: node.shape, text: 'unable to fetch modes' });
+        throw err;
+      });
+    }
 
     node.on('input', async (msg, send, done) => {
       node.status({ fill: 'blue', shape: 'dot', text: 'requesting' });
 
-      const modeId = msg.modeId || node.modeId;
+      let modeId;
+      if (msg.modeId) {
+        modeId = msg.modeId;
+      } else if (msg.mode) {
+        if (this.availableModes[msg.mode] === undefined) {
+          try {
+            await fetchAvailableModes();
+          } catch (err) {
+            return;
+          }
+        }
+        modeId = this.availableModes[msg.mode];
+      } else {
+        modeId = node.modeId;
+      }
+
       if (!modeId) {
         node.status({ fill: 'red', shape: 'ring', text: 'undefined mode' });
         done('undefined mode');

--- a/test/nodes/mode_setter_spec.js
+++ b/test/nodes/mode_setter_spec.js
@@ -161,4 +161,25 @@ describe('Hubitat Mode Setter Node', () => {
       n1.receive({ modeId: '999' });
     });
   });
+  it('should take mode from message', (done) => {
+    const flow = [
+      defaultConfigNode,
+      { ...defaultModeSetterNode, wires: [['n2']] },
+      { id: 'n2', type: 'helper' },
+    ];
+    helper.load([modeSetterNode, configNode], flow, () => {
+      const n1 = helper.getNode('n1');
+      const n2 = helper.getNode('n2');
+      n1.availableModes = { 'far far away': '999' };
+      n2.on('input', (msg) => {
+        try {
+          msg.should.have.property('response', { modeId: '999' });
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      n1.receive({ mode: 'far far away' });
+    });
+  });
 });


### PR DESCRIPTION
If you do not define msg.mode, then nothing more will happen
If you define it, then the node will try to check on its cache and map the mode to an ID. Otherwise it will fetch all available modes on Hubitat