### PR TITLE
device: bind extra argument to the output message

### DIFF
--- a/nodes/device.js
+++ b/nodes/device.js
@@ -101,7 +101,7 @@ module.exports = function HubitatDeviceModule(RED) {
           node.log('Attributes refreshed');
         }
         if (node.sendEvent) {
-          const msg = { ...attribute };
+          const msg = { ...event, ...attribute };
           node.send({ payload: msg, topic: node.name });
         }
       }

--- a/test/nodes/device_spec.js
+++ b/test/nodes/device_spec.js
@@ -72,6 +72,45 @@ describe('Hubitat Device Node', () => {
       n1.hubitat.hubitatEvent.emit('device.42', hubitatEvent);
     });
   });
+  it('should send event with extra properties when event received', (done) => {
+    const flow = [
+      defaultConfigNode,
+      { ...defaultDeviceNode, wires: [['n2']] },
+      { id: 'n2', type: 'helper' },
+    ];
+    const hubitatEvent = {
+      deviceId: '42',
+      name: 'testAttribute',
+      value: 'new-value',
+      dataType: 'overriden attribute',
+      extra: 'extra-arg',
+    };
+    helper.load([deviceNode, configNode], flow, () => {
+      const n1 = helper.getNode('n1');
+      const n2 = helper.getNode('n2');
+      n1.currentAttributes = {
+        testAttribute: {
+          name: 'testAttribute', value: 'old-value', deviceId: '42', dataType: 'STRING',
+        },
+      };
+      n2.on('input', (msg) => {
+        try {
+          msg.should.have.property('payload', {
+            deviceId: '42',
+            name: 'testAttribute',
+            value: 'new-value',
+            currentValue: 'new-value',
+            dataType: 'STRING',
+            extra: 'extra-arg',
+          });
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      n1.hubitat.hubitatEvent.emit('device.42', hubitatEvent);
+    });
+  });
   it('should not send event when event received with wrong deviceId', (done) => {
     const flow = [
       defaultConfigNode,


### PR DESCRIPTION
reason: some driver can add useful information like timestamp or unit or
descriptionText