### PR TITLE
device: fix cast value when attribute is an object

### DIFF
--- a/nodes/device.js
+++ b/nodes/device.js
@@ -5,6 +5,10 @@ module.exports = function HubitatDeviceModule(RED) {
       node.warn(`Unable to cast to dataType. Open an issue to report back the following output: ${dataType}: ${value}`);
       return value;
     }
+
+    if (typeof value !== 'string') {
+      return value;
+    }
     switch (dataType) {
       case 'STRING':
       case 'ENUM':

--- a/test/nodes/device_spec.js
+++ b/test/nodes/device_spec.js
@@ -399,6 +399,29 @@ describe('Hubitat Device Node', () => {
       n1.hubitat.hubitatEvent.emit('device.42', hubitatEvent);
     });
   });
+  it('should not cast event with object value', (done) => {
+    const flow = [
+      defaultConfigNode,
+      { ...defaultDeviceNode, wires: [['n2']] },
+      { id: 'n2', type: 'helper' },
+    ];
+    const hubitatEvent = { name: 'testAttribute', value: { object: 'val' } };
+    helper.load([deviceNode, configNode], flow, () => {
+      const n1 = helper.getNode('n1');
+      const n2 = helper.getNode('n2');
+      n1.currentAttributes = { testAttribute: { value: 'string', dataType: 'UNDEFINED' } };
+
+      n2.on('input', (msg) => {
+        try {
+          msg.payload.should.have.property('value', { object: 'val' });
+          done();
+        } catch (err) {
+          done(err);
+        }
+      });
+      n1.hubitat.hubitatEvent.emit('device.42', hubitatEvent);
+    });
+  });
   it('should send event when systemStart received and desynchronized', (done) => {
     const flow = [
       defaultConfigNode,


### PR DESCRIPTION
reason: when resynchronize cache, the attribute is not always a string.
In this case, we don't want to cast object