### PR TITLE
Experimental websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+* `config`: add option to use WebSocket instead WebHook
+
 ## 1.0.1
 
 * fix issue with rebuild cache when attributes are not string

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -256,7 +256,9 @@
       The <code>systemStart</code> event is triggered any time a Hubitat hub starts up after a power cycle or reboot.</p>
     <p><b>Use websocket</b> will switch the internal mechanism to use Hubitat's websocket instead of webhook.
       Using websocket should reduce the delay before receiving event (e.g. by ~ 50 ms).
-      Warning: Some event attributes can be different or missing. (ex: type: digitial)</p>
+      This option remove usage of the webhook configuration section and node status icons will be green instead of blue.
+      Warning: Some event attributes can be different or missing. (ex: <code>type: digitial</code>)
+    </p>
     <p>
       <b>Warning:</b> This node add an unauthenticated webhook endpoint (default: <code>/hubitat/webhook</code>),
       which can be a security issue if you expose it on internet.

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -90,6 +90,21 @@
       if (!nodeRedServer.val()) {
         nodeRedServer.val(window.location.origin);
       }
+
+      const useWebsocket = $('#node-config-input-useWebsocket');
+      function disableWebhook() {
+        if(useWebsocket.is(':checked')){
+          $('#node-config-input-nodeRedServer').attr('disabled', 'disabled');
+          $('#node-config-input-webhookPath').attr('disabled', 'disabled');
+          $('#node-config-button-webhookConfigure').attr('disabled', 'disabled');
+        } else {
+          $('#node-config-input-nodeRedServer').removeAttr('disabled');
+          $('#node-config-input-webhookPath').removeAttr('disabled');
+          $('#node-config-button-webhookConfigure').removeAttr('disabled');
+        }
+      }
+      useWebsocket.click(disableWebhook);
+      disableWebhook();
     }
   });
 

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -230,7 +230,6 @@
     <p>Server field must not contains the scheme (<code>http://</code> or <code>https://</code>).</p>
     <p>The <code>Webhook Section</code> allow to configure the URL on which the Hubitat hub will send events.
       Ensure that Node-RED is reachable by the Hubitat hub</p>
-    <p>
     <p><b>Rebuild cache on Hubitat <code>systemStart</code> event</b> will rebuild the Node-RED cache for the Hubitat nodes.
       During the rebuild, if a difference is found between the current Hubitat attribute value and the previous cached value a new event msg for each changed attribute will be sent from the applicable nodes.
       If the current Hubitat attribute value is unchanged from the previous cached value, then no event msg will be sent.

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -49,6 +49,7 @@
       nodeRedServer: { value: '', validate: validatorNodeRedServer },
       webhookPath: { value: '/hubitat/webhook', validate: validatorWebhookPath },
       autoRefresh: { value: true },
+      useWebsocket: { value: false },
     },
     credentials: { token: { required: true, type: 'text' } },
     label: function() {
@@ -215,6 +216,10 @@
         <label for="node-config-input-autoRefresh" style="width: auto; margin-right: 5px;">Rebuild cache on Hubitat <code>systemStart</code> event</label>
         <input type="checkbox" id="node-config-input-autoRefresh" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
+      <div class="form-row">
+        <label for="node-config-input-useWebsocket" style="width: auto; margin-right: 5px;">Use websocket</label>
+        <input type="checkbox" id="node-config-input-useWebsocket" style="display: inline-block; width: auto; vertical-align: top;">
+      </div>
     </div>
   </div>
 </script>
@@ -234,6 +239,9 @@
       During the rebuild, if a difference is found between the current Hubitat attribute value and the previous cached value a new event msg for each changed attribute will be sent from the applicable nodes.
       If the current Hubitat attribute value is unchanged from the previous cached value, then no event msg will be sent.
       The <code>systemStart</code> event is triggered any time a Hubitat hub starts up after a power cycle or reboot.</p>
+    <p><b>Use websocket</b> will switch the internal mechanism to use Hubitat's websocket instead of webhook.
+      Using websocket should reduce the delay before receiving event (e.g. by ~ 50 ms).
+      Warning: Some event attributes can be different or missing. (ex: type: digitial)</p>
     <p>
       <b>Warning:</b> This node add an unauthenticated webhook endpoint (default: <code>/hubitat/webhook</code>),
       which can be a security issue if you expose it on internet.

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -242,19 +242,28 @@
 <script type="text/html" data-help-name="hubitat config">
   <p>Creates a new Hubitat configuration node</p>
   <h3>Details</h3>
-    <p>Hubitat Maker API must be installed to use this node.
-    All required fields can be found inside example URL
-    <p>In the following example, the application ID is <b>12</b>:
-    <code>http://localhost/apps/api/<b>12</b>/devices?access_token=...</code></p>
-    <p>Token correspond to the <b>access_token</b> value.
-    <p>Server field must not contains the scheme (<code>http://</code> or <code>https://</code>).</p>
-    <p>The <code>Webhook Section</code> allow to configure the URL on which the Hubitat hub will send events.
-      Ensure that Node-RED is reachable by the Hubitat hub</p>
-    <p><b>Rebuild cache on Hubitat <code>systemStart</code> event</b> will rebuild the Node-RED cache for the Hubitat nodes.
+    <p>
+      Hubitat Maker API must be installed to use this node.
+      All required fields can be found inside example URL
+    </p>
+    <p>
+      In the following example, the <b>Application ID</b> is <b>12</b>:
+      <code>http://localhost/apps/api/<b>12</b>/devices?access_token=...</code>
+    </p>
+    <p><b>Token</b> correspond to the <b>access_token</b> value.
+    <p><b>Server</b> field must not contains the scheme (<code>http://</code> or <code>https://</code>).</p>
+    <p>
+      The <b>Webhook configuration</b> section allow to configure the URL on which the Hubitat hub will send events.
+      Ensure that Node-RED is reachable by the Hubitat hub
+    </p>
+    <p>
+      <b>Rebuild cache on Hubitat <code>systemStart</code> event</b> will rebuild the Node-RED cache for the Hubitat nodes.
       During the rebuild, if a difference is found between the current Hubitat attribute value and the previous cached value a new event msg for each changed attribute will be sent from the applicable nodes.
       If the current Hubitat attribute value is unchanged from the previous cached value, then no event msg will be sent.
-      The <code>systemStart</code> event is triggered any time a Hubitat hub starts up after a power cycle or reboot.</p>
-    <p><b>Use websocket</b> will switch the internal mechanism to use Hubitat's websocket instead of webhook.
+      The <code>systemStart</code> event is triggered any time a Hubitat hub starts up after a power cycle or reboot.
+    </p>
+    <p>
+      <b>Use websocket</b> will switch the internal mechanism to use Hubitat's websocket instead of webhook.
       Using websocket should reduce the delay before receiving event (e.g. by ~ 50 ms).
       This option remove usage of the webhook configuration section and node status icons will be green instead of blue.
       Warning: Some event attributes can be different or missing. (ex: <code>type: digitial</code>)
@@ -262,5 +271,6 @@
     <p>
       <b>Warning:</b> This node add an unauthenticated webhook endpoint (default: <code>/hubitat/webhook</code>),
       which can be a security issue if you expose it on internet.
+      Please read Node-RED documentation to add security on routes exposed by HTTP.
     </p>
 </script>

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -136,9 +136,11 @@ module.exports = function HubitatConfigModule(RED) {
         node.wsServer = socket; // keep for closing
 
         socket.on('open', () => {
+          node.log('Websocket connected');
           node.hubitatEvent.emit('websocket-opened');
         });
         socket.on('close', () => {
+          node.log('Websocket closed');
           node.hubitatEvent.emit('websocket-closed');
           if (!node.closing) {
             clearTimeout(node.wsTimeout);
@@ -156,6 +158,7 @@ module.exports = function HubitatConfigModule(RED) {
           }
         });
         socket.on('error', (err) => {
+          node.error(`Websocket error: ${JSON.stringify(err)}`);
           node.hubitatEvent.emit('websocket-error', { error: err });
           clearTimeout(node.wsTimeout);
           node.wsTimeout = setTimeout(() => { startWebsocket(); }, 3000); // 3 sec

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -131,7 +131,8 @@ module.exports = function HubitatConfigModule(RED) {
       const startWebsocket = () => {
         node.reconnectTimeout = null;
         node.pingTimeout = null;
-        const socket = new WebSocket(`ws://${node.host}/eventsocket`);
+        const wsScheme = ((this.usetls) ? 'wss' : 'ws');
+        const socket = new WebSocket(`${wsScheme}://${node.host}/eventsocket`);
         socket.setMaxListeners(0);
         node.wsServer = socket; // keep for closing
 

--- a/nodes/device.js
+++ b/nodes/device.js
@@ -88,8 +88,10 @@ module.exports = function HubitatDeviceModule(RED) {
       }
       if (node.hubitat.useWebsocket) {
         if (fill === null) {
-          status.fill = 'blue';
+          status.fill = 'green';
           status.shape = this.shape;
+        } else if (fill === 'blue') {
+          status.fill = 'green';
         }
         if (node.currentStatusWs !== 'OK') {
           status.fill = 'red';

--- a/nodes/event.js
+++ b/nodes/event.js
@@ -11,6 +11,8 @@ module.exports = function HubitatEventModule(RED) {
       return;
     }
 
+    node.status({}); // clean status if toggle useWebsocket
+
     const callback = async (event) => {
       node.debug(`Event received: ${JSON.stringify(event)}`);
       node.log(`Event: ${event.name}`);
@@ -24,13 +26,11 @@ module.exports = function HubitatEventModule(RED) {
     this.hubitat.hubitatEvent.on('event', callback);
 
     const wsOpened = async () => {
-      const successIcon = '\u2713'; // check mark
-      node.status({ text: `[${successIcon}]` });
+      node.status({ fill: 'blue', shape: 'ring', text: '' });
     };
     this.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
     const wsClosed = async () => {
-      const failIcon = '\u2717'; // cross mark
-      node.status({ text: `[${failIcon}]` });
+      node.status({ fill: 'red', shape: 'ring', text: 'WS ERROR' });
     };
     this.hubitat.hubitatEvent.on('websocket-closed', wsClosed);
     this.hubitat.hubitatEvent.on('websocket-error', wsClosed);

--- a/nodes/event.js
+++ b/nodes/event.js
@@ -23,9 +23,24 @@ module.exports = function HubitatEventModule(RED) {
     };
     this.hubitat.hubitatEvent.on('event', callback);
 
+    const wsOpened = async () => {
+      const successIcon = '\u2713'; // check mark
+      node.status({ text: `[${successIcon}]` });
+    };
+    this.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
+    const wsClosed = async () => {
+      const failIcon = '\u2717'; // cross mark
+      node.status({ text: `[${failIcon}]` });
+    };
+    this.hubitat.hubitatEvent.on('websocket-closed', wsClosed);
+    this.hubitat.hubitatEvent.on('websocket-error', wsClosed);
+
     node.on('close', () => {
       node.debug('Closed');
       this.hubitat.hubitatEvent.removeListener('event', callback);
+      this.hubitat.hubitatEvent.removeListener('websocket-opened', wsOpened);
+      this.hubitat.hubitatEvent.removeListener('websocket-closed', wsClosed);
+      this.hubitat.hubitatEvent.removeListener('websocket-error', wsClosed);
     });
   }
 

--- a/nodes/event.js
+++ b/nodes/event.js
@@ -26,7 +26,7 @@ module.exports = function HubitatEventModule(RED) {
     this.hubitat.hubitatEvent.on('event', callback);
 
     const wsOpened = async () => {
-      node.status({ fill: 'blue', shape: 'ring', text: '' });
+      node.status({ fill: 'green', shape: 'ring', text: '' });
     };
     this.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
     const wsClosed = async () => {

--- a/nodes/location.js
+++ b/nodes/location.js
@@ -12,6 +12,8 @@ module.exports = function HubitatLocationModule(RED) {
       return;
     }
 
+    node.status({}); // clean status if toggle useWebsocket
+
     const callback = async (event) => {
       node.debug(`Event received: ${JSON.stringify(event)}`);
       node.log(`Location Event: ${event.name}`);
@@ -29,9 +31,22 @@ module.exports = function HubitatLocationModule(RED) {
     };
     this.hubitat.hubitatEvent.on('location', callback);
 
+    const wsOpened = async () => {
+      node.status({ fill: 'blue', shape: 'ring', text: '' });
+    };
+    this.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
+    const wsClosed = async () => {
+      node.status({ fill: 'red', shape: 'ring', text: 'WS ERROR' });
+    };
+    this.hubitat.hubitatEvent.on('websocket-closed', wsClosed);
+    this.hubitat.hubitatEvent.on('websocket-error', wsClosed);
+
     node.on('close', () => {
       node.debug('Closed');
       this.hubitat.hubitatEvent.removeListener('location', callback);
+      this.hubitat.hubitatEvent.removeListener('websocket-opened', wsOpened);
+      this.hubitat.hubitatEvent.removeListener('websocket-closed', wsClosed);
+      this.hubitat.hubitatEvent.removeListener('websocket-error', wsClosed);
     });
   }
 

--- a/nodes/location.js
+++ b/nodes/location.js
@@ -32,7 +32,7 @@ module.exports = function HubitatLocationModule(RED) {
     this.hubitat.hubitatEvent.on('location', callback);
 
     const wsOpened = async () => {
-      node.status({ fill: 'blue', shape: 'ring', text: '' });
+      node.status({ fill: 'green', shape: 'ring', text: '' });
     };
     this.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
     const wsClosed = async () => {

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -30,8 +30,10 @@ module.exports = function HubitatModeModule(RED) {
       }
       if (node.hubitat.useWebsocket) {
         if (fill === null) {
-          status.fill = 'blue';
+          status.fill = 'green';
           status.shape = this.shape;
+        } else if (fill === 'blue') {
+          status.fill = 'green';
         }
         if (node.currentStatusWs !== 'OK') {
           status.fill = 'red';

--- a/nodes/mode.js
+++ b/nodes/mode.js
@@ -7,21 +7,49 @@ module.exports = function HubitatModeModule(RED) {
     this.sendEvent = config.sendEvent;
     this.currentMode = undefined;
     this.shape = this.sendEvent ? 'dot' : 'ring';
+    this.currentStatusText = '';
+    this.currentStatusFill = undefined;
+    this.currentStatusWs = 'NOK';
     const node = this;
 
     if (!node.hubitat) {
       node.error('Hubitat server not configured');
       return;
     }
+    this.updateStatus = (fill = null, text = null) => {
+      const status = { fill, shape: this.shape, text };
+      node.currentStatusText = text;
+      node.currentStatusFill = fill;
+
+      if (fill === null) {
+        delete status.shape;
+        delete status.fill;
+      }
+      if (text === null) {
+        delete status.text;
+      }
+      if (node.hubitat.useWebsocket) {
+        if (fill === null) {
+          status.fill = 'blue';
+          status.shape = this.shape;
+        }
+        if (node.currentStatusWs !== 'OK') {
+          status.fill = 'red';
+          status.text = 'WS ERROR';
+        }
+      }
+      node.status(status);
+    };
+
     async function initializeMode() {
       return node.hubitat.getMode().then((mode) => {
         if (!mode) { throw new Error(JSON.stringify(mode)); }
         node.currentMode = mode.filter((eachMode) => eachMode.active)[0].name;
         node.log(`Initialized. mode: ${node.currentMode}`);
-        node.status({ fill: 'blue', shape: node.shape, text: node.currentMode });
+        node.updateStatus('blue', node.currentMode);
       }).catch((err) => {
         node.warn(`Unable to initialize mode: ${err.message}`);
-        node.status({ fill: 'red', shape: node.shape, text: 'Uninitialized' });
+        node.updateStatus('red', 'Uninitialized');
         throw err;
       });
     }
@@ -43,7 +71,7 @@ module.exports = function HubitatModeModule(RED) {
         };
         node.send(msg);
       }
-      node.status({ fill: 'blue', shape: node.shape, text: node.currentMode });
+      node.updateStatus('blue', node.currentMode);
     };
     this.hubitat.hubitatEvent.on('mode', eventCallback);
 
@@ -61,6 +89,18 @@ module.exports = function HubitatModeModule(RED) {
       }
     };
     this.hubitat.hubitatEvent.on('systemStart', systemStartCallback);
+
+    const wsOpened = async () => {
+      node.currentStatusWs = 'OK';
+      node.updateStatus(node.currentStatusFill, node.currentStatusText);
+    };
+    this.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
+    const wsClosed = async () => {
+      node.currentStatusWs = 'NOK';
+      node.updateStatus(node.currentStatusFill, node.currentStatusText);
+    };
+    this.hubitat.hubitatEvent.on('websocket-closed', wsClosed);
+    this.hubitat.hubitatEvent.on('websocket-error', wsClosed);
 
     initializeMode().catch(() => {});
 
@@ -82,10 +122,14 @@ module.exports = function HubitatModeModule(RED) {
       send(output);
       done();
     });
+
     node.on('close', () => {
       node.debug('Closed');
       this.hubitat.hubitatEvent.removeListener('mode', eventCallback);
       this.hubitat.hubitatEvent.removeListener('systemStart', systemStartCallback);
+      this.hubitat.hubitatEvent.removeListener('websocket-opened', wsOpened);
+      this.hubitat.hubitatEvent.removeListener('websocket-closed', wsClosed);
+      this.hubitat.hubitatEvent.removeListener('websocket-error', wsClosed);
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,6 +349,15 @@
         "@types/mime": "*"
       }
     },
+    "@types/ws": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -536,8 +545,7 @@
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "dev": true
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5374,7 +5382,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
       "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
-      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "body-parser": "^1.19.0",
     "cookie-parser": "^1.4.4",
     "events": "^3.0.0",
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "ws": "^6.2.1"
   },
   "keywords": [
     "node-red",
@@ -40,6 +41,7 @@
     "@types/cookie-parser": "^1.4.2",
     "@types/events": "^3.0.0",
     "@types/node-fetch": "^2.5.7",
+    "@types/ws": "^7.2.5",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",


### PR DESCRIPTION
This feature will not replace the default webhook but only offers an alternative to gain some speed in flows
On my machine, an event was faster by ~ 50 ms when using websocket
The diff may seems huge, but honestly this feature don't impact nodes logic at all ! Only small impact on node statuses. You should check commit by commit to see that's not a big change

## Activate websocket
Check the following checkbox:
![Screenshot from 2020-06-20 15-38-34](https://user-images.githubusercontent.com/11160579/85210231-2b8f1c00-b30c-11ea-8376-07b4d8373ff3.png)
## What's changes
### Status (or message below node)
For node that's already have a status:
* The websocket connection status will override current node status only if an error occurs
![Screenshot from 2020-06-20 15-44-03](https://user-images.githubusercontent.com/11160579/85210482-2763fe00-b30e-11ea-82f9-be76395e3064.png)

For node without status
* A status will be displayed with only the icon to know the websocket connection
![Screenshot from 2020-06-21 11-15-51](https://user-images.githubusercontent.com/11160579/85228288-a90c6800-b3b0-11ea-80f5-e25709782d5f.png)

The circle or dot shape of the icon remains with the same meaning (e.i. if the node send or not events)
When using websocket, the color status icon is green and with the webhook it's blue
![Screenshot from 2020-06-21 11-17-33](https://user-images.githubusercontent.com/11160579/85228334-e7098c00-b3b0-11ea-9075-52627be9d3a0.png)![Screenshot from 2020-06-21 11-17-50](https://user-images.githubusercontent.com/11160579/85228333-e53fc880-b3b0-11ea-835c-c740912c17d0.png)


### No need to fill webhook section
When you use websocket, the webhook configuration section become useless and is disabled

## Limitations
### Event properties
As mentioned  in the documentation, the websocket events don't have the same properties as the webhook event. So be careful if you switch between these two modes