### PR TITLE
improve documentation about websocket

### DIFF
--- a/nodes/config.html
+++ b/nodes/config.html
@@ -232,7 +232,7 @@
         <input type="checkbox" id="node-config-input-autoRefresh" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
       <div class="form-row">
-        <label for="node-config-input-useWebsocket" style="width: auto; margin-right: 5px;">Use websocket</label>
+        <label for="node-config-input-useWebsocket" style="width: auto; margin-right: 5px;">Use websocket (<b>not recommended</b>)</label>
         <input type="checkbox" id="node-config-input-useWebsocket" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
     </div>
@@ -264,9 +264,12 @@
     </p>
     <p>
       <b>Use websocket</b> will switch the internal mechanism to use Hubitat's websocket instead of webhook.
-      Using websocket should reduce the delay before receiving event (e.g. by ~ 50 ms).
-      This option remove usage of the webhook configuration section and node status icons will be green instead of blue.
-      Warning: Some event attributes can be different or missing. (ex: <code>type: digitial</code>)
+      Websocket send duplicate events and their attributes can be different or missing. (ex: <code>type: digitial</code>)
+      But using websocket should reduce the delay before receiving event from a few tens of milliseconds.
+      It should only be used by informed people and for specific needed.
+      <p>
+        <b>Warning:</b> Using websocket is not officialy supported and it's at your own risk
+      </p>
     </p>
     <p>
       <b>Warning:</b> This node add an unauthenticated webhook endpoint (default: <code>/hubitat/webhook</code>),

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -263,12 +263,15 @@
       The <code>systemStart</code> event is triggered any time a Hubitat hub starts up after a power cycle or reboot.
     </p>
     <p>
-      <b>Use websocket</b> will switch the internal mechanism to use Hubitat's websocket instead of webhook.
-      Websocket send duplicate events and their attributes can be different or missing. (ex: <code>type: digitial</code>)
-      But using websocket should reduce the delay before receiving event from a few tens of milliseconds.
-      It should only be used by informed people and for specific needed.
+      <b>Use websocket</b> will switch the internal update mechanism to use Hubitat's websocket instead of webhook.
+      Websocket does not perform event de-duplication and will send duplicate events which may require additional handling in Node-RED
+      (such as use of an RBE node) to prevent unintended re-activation of logic.
+      Websocket events contain less information, and may not have all event data that the webhook method does
+      (e,g, lock code used for lock/unlock events, and the event "type" field).
+      But using websocket should reduce the delay before receiving events by a few tens of milliseconds.
+      The websocket update method should only be used by informed users, and only for specific needs
       <p>
-        <b>Warning:</b> Using websocket is not officialy supported and it's at your own risk
+        <b>Warning:</b> Using websocket is not officially supported, and it's at your own risk!
       </p>
     </p>
     <p>


### PR DESCRIPTION
## Issue
A lot of people use websocket without being informed of consequences
It results to a lot of questions and help on forum

## Proposition
This PR improve documentation about consequence of websocket and add a `not recommended` flag to discourage people to use it

What I tried to do with these modifications
* have a visual warning directly on the option name (the `not recommended`).
  * because nobody read the doc
* describe impactful consequence to use websocket

### Before
![Screenshot from 2020-07-22 21-00-40](https://user-images.githubusercontent.com/11160579/88243468-7d55f980-cc5e-11ea-8f1f-9474de805d83.png)
![Screenshot from 2020-07-22 21-00-54](https://user-images.githubusercontent.com/11160579/88243469-7f1fbd00-cc5e-11ea-80ed-0c1e996d85b7.png)

### After
![Screenshot from 2020-07-22 20-37-05](https://user-images.githubusercontent.com/11160579/88243382-3cf67b80-cc5e-11ea-93c3-73379c7c8164.png)
![Screenshot from 2020-07-22 20-38-37](https://user-images.githubusercontent.com/11160579/88243376-3962f480-cc5e-11ea-870b-2a6d92bb34f6.png)

## Other ideas
* Add a use case to use websocket in the `README.md` (i.e. using two config nodes)
* Add a confirm dialog when you active the option
  * but it's overkill and user have some responsibilities (i.e. read the doc...)
* Add a big warning at the top of the `Advanced` tab that said that only informed people should modified these options