### PR TITLE
Pull request for log-node-id

### DIFF
--- a/nodes/command.js
+++ b/nodes/command.js
@@ -31,8 +31,9 @@ module.exports = function HubitatCommandModule(RED) {
 
       const deviceId = ((msg.deviceId !== undefined) ? msg.deviceId : node.deviceId);
       if (!deviceId) {
-        node.status({ fill: 'red', shape: 'ring', text: 'undefined deviceId' });
-        done('undefined deviceId');
+        const errorMsg = 'undefined deviceId';
+        node.status({ fill: 'red', shape: 'ring', text: errorMsg });
+        done(errorMsg);
         return;
       }
 
@@ -45,8 +46,9 @@ module.exports = function HubitatCommandModule(RED) {
         commandArgs = msg.arguments;
       }
       if (!command) {
-        node.status({ fill: 'red', shape: 'ring', text: 'undefined command' });
-        done('undefined command');
+        const errorMsg = 'undefined deviceId';
+        node.status({ fill: 'red', shape: 'ring', text: errorMsg });
+        done(errorMsg);
         return;
       }
 

--- a/nodes/command.js
+++ b/nodes/command.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 module.exports = function HubitatCommandModule(RED) {
   const fetch = require('node-fetch');
+  const doneWithId = require('./utils/done-with-id');
 
   function HubitatCommandNode(config) {
     RED.nodes.createNode(this, config);
@@ -33,7 +34,7 @@ module.exports = function HubitatCommandModule(RED) {
       if (!deviceId) {
         const errorMsg = 'undefined deviceId';
         node.status({ fill: 'red', shape: 'ring', text: errorMsg });
-        done(errorMsg);
+        doneWithId(node, done, errorMsg);
         return;
       }
 
@@ -48,7 +49,7 @@ module.exports = function HubitatCommandModule(RED) {
       if (!command) {
         const errorMsg = 'undefined deviceId';
         node.status({ fill: 'red', shape: 'ring', text: errorMsg });
-        done(errorMsg);
+        doneWithId(node, done, errorMsg);
         return;
       }
 
@@ -64,7 +65,7 @@ module.exports = function HubitatCommandModule(RED) {
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          done(await response.text());
+          doneWithId(node, done, await response.text());
           return;
         }
         const output = { ...msg, response: await response.json() };

--- a/nodes/hsm-setter.js
+++ b/nodes/hsm-setter.js
@@ -58,15 +58,17 @@ module.exports = function HubitatModeSetterModule(RED) {
 
       const rawState = msg.state || node.state;
       if (!rawState) {
-        node.status({ fill: 'red', shape: 'ring', text: 'undefined state' });
-        done('undefined hsm');
+        const errorMsg = 'invalid state';
+        node.status({ fill: 'red', shape: 'ring', text: errorMsg });
+        done(errorMsg);
         return;
       }
 
       const state = convertAlarmState(rawState);
       if (state === 'invalid') {
-        node.status({ fill: 'red', shape: node.shape, text: 'invalid state' });
-        done('invalid state');
+        const errorMsg = 'invalid state';
+        node.status({ fill: 'red', shape: node.shape, text: errorMsg });
+        done(errorMsg);
         return;
       }
 

--- a/nodes/hsm-setter.js
+++ b/nodes/hsm-setter.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 module.exports = function HubitatModeSetterModule(RED) {
   const fetch = require('node-fetch');
+  const doneWithId = require('./utils/done-with-id');
 
   // All possible HE event values: https://github.com/fblackburn1/node-red-contrib-hubitat/pull/9#issuecomment-602258248
   // Conveniant to pass the event value directly in the message property
@@ -60,7 +61,7 @@ module.exports = function HubitatModeSetterModule(RED) {
       if (!rawState) {
         const errorMsg = 'invalid state';
         node.status({ fill: 'red', shape: 'ring', text: errorMsg });
-        done(errorMsg);
+        doneWithId(node, done, errorMsg);
         return;
       }
 
@@ -68,7 +69,7 @@ module.exports = function HubitatModeSetterModule(RED) {
       if (state === 'invalid') {
         const errorMsg = 'invalid state';
         node.status({ fill: 'red', shape: node.shape, text: errorMsg });
-        done(errorMsg);
+        doneWithId(node, done, errorMsg);
         return;
       }
 
@@ -79,7 +80,7 @@ module.exports = function HubitatModeSetterModule(RED) {
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          done(await response.text());
+          doneWithId(node, done, await response.text());
           return;
         }
         const output = { ...msg, response: await response.json() };
@@ -88,7 +89,7 @@ module.exports = function HubitatModeSetterModule(RED) {
         done();
       } catch (err) {
         node.status({ fill: 'red', shape: 'ring', text: err.code });
-        done(err);
+        doneWithId(node, done, err);
       }
     });
   }

--- a/nodes/mode-setter.js
+++ b/nodes/mode-setter.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 module.exports = function HubitatModeSetterModule(RED) {
   const fetch = require('node-fetch');
+  const doneWithId = require('./utils/done-with-id');
 
   function HubitatModeSetterNode(config) {
     RED.nodes.createNode(this, config);
@@ -51,7 +52,7 @@ module.exports = function HubitatModeSetterModule(RED) {
       if (!modeId) {
         const errorMsg = 'undefined mode';
         node.status({ fill: 'red', shape: 'ring', text: errorMsg });
-        done(errorMsg);
+        doneWithId(node, done, errorMsg);
         return;
       }
 
@@ -62,7 +63,7 @@ module.exports = function HubitatModeSetterModule(RED) {
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          done(await response.text());
+          doneWithId(node, done, await response.text());
           return;
         }
         const output = { ...msg, response: await response.json() };
@@ -71,7 +72,7 @@ module.exports = function HubitatModeSetterModule(RED) {
         done();
       } catch (err) {
         node.status({ fill: 'red', shape: 'ring', text: err.code });
-        done(err);
+        doneWithId(node, done, err);
       }
     });
   }

--- a/nodes/mode-setter.js
+++ b/nodes/mode-setter.js
@@ -49,8 +49,9 @@ module.exports = function HubitatModeSetterModule(RED) {
       }
 
       if (!modeId) {
-        node.status({ fill: 'red', shape: 'ring', text: 'undefined mode' });
-        done('undefined mode');
+        const errorMsg = 'undefined mode';
+        node.status({ fill: 'red', shape: 'ring', text: errorMsg });
+        done(errorMsg);
         return;
       }
 

--- a/nodes/request.js
+++ b/nodes/request.js
@@ -19,8 +19,9 @@ module.exports = function HubitatRequestModule(RED) {
 
       const path = msg.path || node.path;
       if (!path) {
-        node.status({ fill: 'red', shape: 'ring', text: 'undefined path' });
-        done('undefined path');
+        const errorMsg = 'undefined path';
+        node.status({ fill: 'red', shape: 'ring', text: errorMsg });
+        done(errorMsg);
         return;
       }
       const url = `${node.hubitat.baseUrl}/${path}?access_token=${node.hubitat.token}`;

--- a/nodes/request.js
+++ b/nodes/request.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 module.exports = function HubitatRequestModule(RED) {
   const fetch = require('node-fetch');
+  const doneWithId = require('./utils/done-with-id');
 
   function HubitatRequestNode(config) {
     RED.nodes.createNode(this, config);
@@ -21,7 +22,7 @@ module.exports = function HubitatRequestModule(RED) {
       if (!path) {
         const errorMsg = 'undefined path';
         node.status({ fill: 'red', shape: 'ring', text: errorMsg });
-        done(errorMsg);
+        doneWithId(node, done, errorMsg);
         return;
       }
       const url = `${node.hubitat.baseUrl}/${path}?access_token=${node.hubitat.token}`;
@@ -31,7 +32,7 @@ module.exports = function HubitatRequestModule(RED) {
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          done(await response.text());
+          doneWithId(node, done, await response.text());
           return;
         }
         const output = { ...msg, payload: await response.json() };
@@ -40,7 +41,7 @@ module.exports = function HubitatRequestModule(RED) {
         done();
       } catch (err) {
         node.status({ fill: 'red', shape: 'ring', text: err.code });
-        done(err);
+        doneWithId(node, done, err);
       }
     });
   }

--- a/nodes/utils/done-with-id.js
+++ b/nodes/utils/done-with-id.js
@@ -1,0 +1,8 @@
+function doneWithId(node, done, msg) {
+  let message = msg;
+  if (node.name) {
+    message = `[${node.id}] ${message}`;
+  }
+  done(message);
+}
+module.exports = doneWithId;


### PR DESCRIPTION
reason: by default node-red will write node id only if name is unset.
Otherwise it will use node name in log which can be hard to troubleshoot
if you have a lot of node with same name