### PR TITLE
improve error logger to include the complete url

### DIFF
--- a/nodes/command.js
+++ b/nodes/command.js
@@ -57,15 +57,18 @@ module.exports = function HubitatCommandModule(RED) {
       if ((commandArgs != null) && (commandArgs !== '')) {
         commandWithArgs = `${command}/${encodeURIComponent(commandArgs)}`;
       }
-      const url = `${node.hubitat.baseUrl}/devices/${deviceId}/${commandWithArgs}?access_token=${node.hubitat.token}`;
+      const baseUrl = `${node.hubitat.baseUrl}/devices/${deviceId}/${commandWithArgs}`;
+      const url = `${baseUrl}?access_token=${node.hubitat.token}`;
       const options = { method: 'GET' };
 
       try {
         await node.hubitat.acquireLock();
+        node.debug(`Request: ${baseUrl}`);
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          doneWithId(node, done, await response.text());
+          const message = `${baseUrl}: ${await response.text()}`;
+          doneWithId(node, done, message);
           return;
         }
         const output = { ...msg, response: await response.json() };

--- a/nodes/hsm-setter.js
+++ b/nodes/hsm-setter.js
@@ -73,14 +73,17 @@ module.exports = function HubitatModeSetterModule(RED) {
         return;
       }
 
-      const url = `${node.hubitat.baseUrl}/hsm/${state}?access_token=${node.hubitat.token}`;
+      const baseUrl = `${node.hubitat.baseUrl}/hsm/${state}`;
+      const url = `${baseUrl}?access_token=${node.hubitat.token}`;
       const options = { method: 'GET' };
 
       try {
+        node.debug(`Request: ${baseUrl}`);
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          doneWithId(node, done, await response.text());
+          const message = `${baseUrl}: ${await response.text()}`;
+          doneWithId(node, done, message);
           return;
         }
         const output = { ...msg, response: await response.json() };

--- a/nodes/mode-setter.js
+++ b/nodes/mode-setter.js
@@ -56,14 +56,17 @@ module.exports = function HubitatModeSetterModule(RED) {
         return;
       }
 
-      const url = `${node.hubitat.baseUrl}/modes/${modeId}?access_token=${node.hubitat.token}`;
+      const baseUrl = `${node.hubitat.baseUrl}/modes/${modeId}`;
+      const url = `${baseUrl}?access_token=${node.hubitat.token}`;
       const options = { method: 'GET' };
 
       try {
+        node.debug(`Request: ${baseUrl}`);
         const response = await fetch(url, options);
         if (response.status >= 400) {
           node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          doneWithId(node, done, await response.text());
+          const message = `${baseUrl}: ${await response.text()}`;
+          doneWithId(node, done, message);
           return;
         }
         const output = { ...msg, response: await response.json() };


### PR DESCRIPTION
reason: easier to debug when some parameters are provided dynamically
(by the message)

result for command node
```
13 Oct 22:38:38 - [debug] [hubitat command:Outlet] Request: http://192.168.1.2:80/apps/api/100/devices/1/refresh                                                                                         
13 Oct 22:38:39 - [error] [hubitat command:Outlet] [cc0f9e8b.56b2f] http://192.168.1.2:80/apps/api/100/devices/1/refresh: {"error":true,"type":"java.lang.Exception","message":"An unexpected error occurred."}
```