### PR TITLE
config: support httpNodeRoot when setting webhook

### DIFF
--- a/nodes/config.html
+++ b/nodes/config.html
@@ -85,6 +85,19 @@
         label: 'Advanced',
       });
 
+      let httpNodeRoot = RED.settings.httpNodeRoot;
+      if (httpNodeRoot.slice(-1) === '/') {
+        httpNodeRoot = httpNodeRoot.slice(0, -1);
+      }
+
+      const httpNodeRootInput = $('#node-config-input-httpNodeRoot');
+      if (httpNodeRoot === '') {
+        httpNodeRootInput.hide()
+      } else {
+        httpNodeRootInput.width((httpNodeRoot.length) * 8);
+        httpNodeRootInput.val(httpNodeRoot);
+      }
+
       let nodeRedServer = $('#node-config-input-nodeRedServer');
       nodeRedServer.attr('placeholder', window.location.origin);
       if (!nodeRedServer.val()) {
@@ -203,10 +216,11 @@
       <div class="form-row">
         <p><b>Webhook configuration</b></p>
       </div>
-      <div class="form-row" style="padding-right: 200px">
+      <div class="form-row" style="display: flex; flex-direction: row;">
         <label for="node-config-input-nodeRedServer"><i class="fa fa-globe"></i> Node-RED</label>
-        <input type="text" id="node-config-input-nodeRedServer">
-        <input type="text" id="node-config-input-webhookPath" style="width:200px; margin-right:-200px; float:right;" placeholder="/hubitat/webhook">
+        <input type="text" id="node-config-input-nodeRedServer" style="width:205px;">
+        <input type="text" id="node-config-input-httpNodeRoot" readonly>
+        <input type="text" id="node-config-input-webhookPath" style="width:auto" placeholder="/hubitat/webhook">
       </div>
       <div class="form-row">
         <button id="node-config-button-webhookConfigure" onclick="configureHubitat()">Configure webhook</button>

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -485,7 +485,11 @@ ${dataType}: ${value} \
     const scheme = ((req.body.usetls === 'true') ? 'https' : 'http');
     const baseUrl = `${scheme}://${req.body.host}:${req.body.port}/apps/api/${req.body.appId}`;
     const options = { method: 'GET' };
-    const nodeRedURL = encodeURIComponent(`${req.body.nodeRedServer}${req.body.webhookPath}`);
+    let { httpNodeRoot } = RED.settings;
+    if (httpNodeRoot.slice(-1) === '/') {
+      httpNodeRoot = httpNodeRoot.slice(0, -1);
+    }
+    const nodeRedURL = encodeURIComponent(`${req.body.nodeRedServer}${httpNodeRoot}${req.body.webhookPath}`);
     let url = `${baseUrl}/postURL/${nodeRedURL}`;
     console.log(`GET ${url}`);
     url = `${url}?access_token=${req.body.token}`;


### PR DESCRIPTION
reason: httpNodeRoot is set by default to /endpoint on Home Assistant
installation. It will remove manual configuration steps