### PR TITLE
config: allow to set a color by config node

### DIFF
--- a/nodes/config.html
+++ b/nodes/config.html
@@ -39,6 +39,49 @@
     $('#node-config-input-host').val(value);
     return true;
   }
+
+  function setNodeColor(node, color) {
+    const workspace = $("#red-ui-workspace-chart").contents();
+    const node_rect = workspace.find('[id="' + node.id + '"]').find('.red-ui-flow-node');
+    node_rect.attr('fill', color);
+  }
+  function updateHubitatNodeAttr(node) {
+    if (node._def.category !== 'hubitat') {
+        return;
+      }
+      configNode = RED.nodes.node(node.server)
+      let color = '#ACE043'
+      if (configNode && configNode.color) {
+        color = configNode.color;
+      }
+      setNodeColor(node, color);
+  }
+  function updateHubitatConfigNodeAttr(node) {
+    const color = node.color || '#ACE043';
+    node.users.forEach((child) => {
+      setNodeColor(child, color);
+    });
+  }
+  RED.events.on('nodes:change', (node) => {
+    if (node.type === 'hubitat config') {
+      updateHubitatConfigNodeAttr(node);
+    } else {
+      updateHubitatNodeAttr(node);
+    }
+  });
+  RED.events.on('nodes:add', (node) => {
+    setTimeout(updateHubitatNodeAttr.bind(this, node), 5);
+  });
+  RED.events.on('workspace:change', (workspace) => {
+    setTimeout(function() {
+      RED.nodes.eachConfig((node) => {
+        if (node.type === 'hubitat config') {
+          updateHubitatConfigNodeAttr(node);
+        }
+      })
+    }, 5); // 0 is enough, but just to be sure
+  });
+
   RED.nodes.registerType('hubitat config', {
     category: 'config',
     defaults: {
@@ -51,6 +94,7 @@
       webhookPath: { value: '/hubitat/webhook', validate: validatorWebhookPath },
       autoRefresh: { value: true },
       useWebsocket: { value: false },
+      color: { value: '#ACE043' },
     },
     credentials: { token: { required: true, type: 'text' } },
     label() {
@@ -250,6 +294,10 @@
         <label for="node-config-input-useWebsocket" style="width: auto; margin-right: 5px;">Use websocket (<b>not recommended</b>)</label>
         <input type="checkbox" id="node-config-input-useWebsocket" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
+      <div class="form-row">
+        <label for="node-config-input-color"><i class="fa fa-paint-brush"></i> Color</label>
+        <input type="color" id="node-config-input-color" style="width: 39px">
+      </div>
     </div>
   </div>
 </script>
@@ -288,6 +336,9 @@
       <p>
         <b>Warning:</b> Using websocket is not officially supported, and it's at your own risk!
       </p>
+    </p>
+    <p>
+      <b>Color</b> option will define a color for all nodes that use this configuration.
     </p>
     <p>
       <b>Warning:</b> This node add an unauthenticated webhook endpoint (default: <code>/hubitat/webhook</code>),

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -1,4 +1,5 @@
 <script type="text/javascript">
+  /* eslint-disable no-underscore-dangle */
   function validatorWebhookPath(rawValue) {
     let value = rawValue;
     if (!value) {
@@ -41,21 +42,21 @@
   }
 
   function setNodeColor(node, color) {
-    const workspace = $("#red-ui-workspace-chart").contents();
-    const node_rect = workspace.find('[id="' + node.id + '"]').find('.red-ui-flow-node');
-    node_rect.attr('fill', color);
+    const workspace = $('#red-ui-workspace-chart').contents();
+    const nodeRect = workspace.find(`[id="${node.id}"]`).find('.red-ui-flow-node');
+    nodeRect.attr('fill', color);
   }
   function getHubitatNodeColor(configNode, node) {
     if (configNode && configNode.colorEnabled && configNode.color) {
       return configNode.color;
     }
-    return RED.utils.getNodeColor(node.type, node._def)
+    return RED.utils.getNodeColor(node.type, node._def);
   }
   function updateHubitatNodeAttr(node) {
     if (node._def.category !== 'hubitat') {
-        return;
+      return;
     }
-    configNode = RED.nodes.node(node.server)
+    const configNode = RED.nodes.node(node.server);
     const color = getHubitatNodeColor(configNode, node);
     setNodeColor(node, color);
   }
@@ -75,13 +76,14 @@
   RED.events.on('nodes:add', (node) => {
     setTimeout(updateHubitatNodeAttr.bind(this, node), 5);
   });
+  // eslint-disable-next-line no-unused-vars
   RED.events.on('workspace:change', (workspace) => {
-    setTimeout(function() {
+    setTimeout(() => {
       RED.nodes.eachConfig((node) => {
         if (node.type === 'hubitat config') {
           updateHubitatConfigNodeAttr(node);
         }
-      })
+      });
     }, 5); // 0 is enough, but just to be sure
   });
 
@@ -169,7 +171,7 @@
 
       const colorEnabled = $('#node-config-input-colorEnabled');
       function disableColor() {
-        if(colorEnabled.is(':checked')){
+        if (colorEnabled.is(':checked')) {
           $('#node-config-input-color').show();
         } else {
           $('#node-config-input-color').hide();

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -45,21 +45,24 @@
     const node_rect = workspace.find('[id="' + node.id + '"]').find('.red-ui-flow-node');
     node_rect.attr('fill', color);
   }
+  function getHubitatNodeColor(configNode, node) {
+    if (configNode && configNode.colorEnabled && configNode.color) {
+      return configNode.color;
+    }
+    return RED.utils.getNodeColor(node.type, node._def)
+  }
   function updateHubitatNodeAttr(node) {
     if (node._def.category !== 'hubitat') {
         return;
-      }
-      configNode = RED.nodes.node(node.server)
-      let color = '#ACE043'
-      if (configNode && configNode.color) {
-        color = configNode.color;
-      }
-      setNodeColor(node, color);
+    }
+    configNode = RED.nodes.node(node.server)
+    const color = getHubitatNodeColor(configNode, node);
+    setNodeColor(node, color);
   }
-  function updateHubitatConfigNodeAttr(node) {
-    const color = node.color || '#ACE043';
-    node.users.forEach((child) => {
-      setNodeColor(child, color);
+  function updateHubitatConfigNodeAttr(configNode) {
+    configNode.users.forEach((node) => {
+      const color = getHubitatNodeColor(configNode, node);
+      setNodeColor(node, color);
     });
   }
   RED.events.on('nodes:change', (node) => {
@@ -94,6 +97,7 @@
       webhookPath: { value: '/hubitat/webhook', validate: validatorWebhookPath },
       autoRefresh: { value: true },
       useWebsocket: { value: false },
+      colorEnabled: { value: false },
       color: { value: '#ACE043' },
     },
     credentials: { token: { required: true, type: 'text' } },
@@ -162,6 +166,17 @@
       }
       useWebsocket.click(disableWebhook);
       disableWebhook();
+
+      const colorEnabled = $('#node-config-input-colorEnabled');
+      function disableColor() {
+        if(colorEnabled.is(':checked')){
+          $('#node-config-input-color').show();
+        } else {
+          $('#node-config-input-color').hide();
+        }
+      }
+      colorEnabled.click(disableColor);
+      disableColor();
     },
   });
 
@@ -294,8 +309,9 @@
         <label for="node-config-input-useWebsocket" style="width: auto; margin-right: 5px;">Use websocket (<b>not recommended</b>)</label>
         <input type="checkbox" id="node-config-input-useWebsocket" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
-      <div class="form-row">
-        <label for="node-config-input-color"><i class="fa fa-paint-brush"></i> Color</label>
+      <div class="form-row" style="height:20px; display: flex; align-items:center;">
+        <label for="node-config-input-color" style="width:auto; margin-right: 5px;"><i class="fa fa-paint-brush"></i> Use custom color</label>
+        <input type="checkbox" id="node-config-input-colorEnabled" style="width:auto; margin-right: 5px;">
         <input type="color" id="node-config-input-color" style="width: 39px">
       </div>
     </div>


### PR DESCRIPTION
Allow to distinguish nodes by the configuration associated
![config-color](https://user-images.githubusercontent.com/11160579/105614782-9d937c00-5d99-11eb-9f3d-3d009d372b47.gif)