### PR TITLE
mode-setter: fix comparaison between string and integer

### DIFF
--- a/nodes/mode-setter.html
+++ b/nodes/mode-setter.html
@@ -20,7 +20,7 @@
     };
     $.getJSON('hubitat/modes', params, (res) => {
       res.forEach((item) => {
-        const selected = modeId === item.id;
+        const selected = parseInt(modeId, 10) === item.id;
         const option = $('<option>', { value: item.id, text: item.name });
         selectMenu.append(option);
         if (selected) { selectMenu.val(item.id).trigger('change'); }


### PR DESCRIPTION
By default dropdown values are string, then it we want to compare it
with integer (returned by API), then we need to cast to integer before