### PR TITLE
command: return msg if error occurs on server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.0 (2023-08-08)
+
+* `command`: A new field `msg.responseStatus` has been added to the response
+
 ## 1.8.1 (2023-01-21)
 
 * `device`: fix uncaught exception when deviceId doesn't exist

--- a/nodes/command.html
+++ b/nodes/command.html
@@ -151,8 +151,16 @@
 
   <h3>Output</h3>
     <dl class="message-properties">
+      <dt class="optional">msg.responseStatus <span class="property-type">integer</span></dt>
+      <dd>The HTTP response return code from the server.
+        Usually 200 if the command is executed and 500 if something went wrong on the server.
+        Other codes may be returned according to Hubitat implementation.
+      </dd>
+    </dl>
+    <dl class="message-properties">
       <dt class="optional">msg.response <span class="property-type">string</span></dt>
-      <dd>The raw response of the server</dd>
+      <dd>The raw response of the server. Usually the device object in json format if <code>msg.responseStatus</code> is 200.
+        Otherwise, a raw string of the error</dd>
     </dl>
     <dl class="message-properties">
       <dt class="optional">msg.requestCommand <span class="property-type">string</span></dt>

--- a/nodes/command.js
+++ b/nodes/command.js
@@ -63,19 +63,22 @@ module.exports = function HubitatCommandModule(RED) {
       try {
         await node.hubitat.acquireLock();
         node.debug(`Request: ${baseUrl}`);
-        const response = await fetch(url, options);
-        if (response.status >= 400) {
-          node.status({ fill: 'red', shape: 'ring', text: 'response error' });
-          const message = `${baseUrl}: ${await response.text()}`;
-          doneWithId(node, done, message);
-          return;
-        }
         const output = {
           ...msg,
-          response: await response.json(),
           requestCommand: command,
           requestArguments: commandArgs,
         };
+        const response = await fetch(url, options);
+        output.responseStatus = response.status;
+        if (response.status >= 400) {
+          node.status({ fill: 'red', shape: 'ring', text: 'response error' });
+          output.response = await response.text();
+          const message = `${baseUrl}: ${output.response}`;
+          send(output);
+          doneWithId(node, done, message);
+          return;
+        }
+        output.response = await response.json();
         node.status(node.defaultStatus);
         send(output);
         done();

--- a/test/nodes/command_spec.js
+++ b/test/nodes/command_spec.js
@@ -123,7 +123,7 @@ describe('Hubitat Command Node', () => {
     });
   });
 
-  it('should not send msg when server return error', (done) => {
+  it('should send msg when server return error', (done) => {
     const flow = [
       defaultConfigNode,
       {
@@ -137,18 +137,18 @@ describe('Hubitat Command Node', () => {
     helper.load([commandNode, configNode], flow, () => {
       const n2 = helper.getNode('n2');
       const n1 = helper.getNode('n1');
-      let inError = false;
       n2.on('input', (msg) => {
-        inError = true;
+        try {
+          msg.should.have.property('responseStatus', 500);
+          msg.should.have.property('response');
+          msg.should.have.property('requestCommand', 'errorCommand');
+          msg.should.have.property('requestArguments', '');
+          done();
+        } catch (err) {
+          done(err);
+        }
       });
       n1.receive();
-      setTimeout(() => {
-        if (inError) {
-          done(new Error('server error allowed though'));
-        } else {
-          done();
-        }
-      }, 20);
     });
   });
 


### PR DESCRIPTION
When an error occurs, to be able to trigger logic, we need to know if the
command has been executed or not
The new output message attribute `msg.responseStatus` will indicate the http
return code from the server and will tell what is inside the `msg.response`
variable:
* `== 200`: the device json representation
* `>= 400`: the raw text output from the server (401 = wrong token, 500 = server error)

Note: this change may break some user logic who consider that only successful command will output a message. But server error are so rare than I'm not too much worried to break this