### PR TITLE
Pull request for fix-script-path-reference

### DIFF
--- a/nodes/command.html
+++ b/nodes/command.html
@@ -1,4 +1,4 @@
-<script src="/hubitat/js/common.js"></script>
+<script src="hubitat/js/common.js"></script>
 
 <script type="text/javascript">
   /* global cleanHubitatSelectMenu, resetHubitatSelectMenu,

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -411,12 +411,12 @@ Supported dataType: https://docs.hubitat.com/index.php?title=Attribute_Object \
     credentials: { token: { type: 'text' } },
   });
 
-  RED.httpAdmin.get('/hubitat/js/*', (req, res) => {
+  RED.httpAdmin.get('/hubitat/js/common.js', (req, res) => {
     const options = {
       root: `${__dirname}/static/`,
       dotfiles: 'deny',
     };
-    res.sendFile(req.params[0], options);
+    res.sendFile('common.js', options);
   });
 
   RED.httpAdmin.get('/hubitat/devices', RED.auth.needsPermission('hubitat.read'), async (req, res) => {

--- a/nodes/device.html
+++ b/nodes/device.html
@@ -1,4 +1,4 @@
-<script src="/hubitat/js/common.js"></script>
+<script src="hubitat/js/common.js"></script>
 
 <script type="text/javascript">
   /* global cleanHubitatDevices, resetHubitatSelectMenu, listHubitatDevices,

--- a/nodes/mode-setter.html
+++ b/nodes/mode-setter.html
@@ -1,4 +1,4 @@
-<script src="/hubitat/js/common.js"></script>
+<script src="hubitat/js/common.js"></script>
 
 <script type="text/javascript">
   /* global cleanHubitatSelectMenu, resetHubitatSelectMenu, loadCredentials, paramsFromServer */


### PR DESCRIPTION
* use relative path to download common.js

reason: using httpAdminRoot option will break absolute path

* hardcode listener endpoint for common.js

reason: to avoid to expose the internal NR directory with the error
message when you enter a wrong file name