### PR TITLE
device: catch exception when deviceId not exists

### DIFF
--- a/nodes/device.js
+++ b/nodes/device.js
@@ -159,20 +159,21 @@ module.exports = function HubitatDeviceModule(RED) {
         return;
       }
 
-      const attributeSearched = msg.attribute || node.attribute;
-      if (!attributeSearched) {
-        msg.payload = { ...node.hubitat.devices[deviceId].attributes };
-        msg.topic = node.topic;
-        send(msg);
-        node.updateStatus();
-        done();
-        return;
-      }
       const device = node.hubitat.devices[deviceId];
       if (!device) {
         const errorMsg = `Device ID (${deviceId}) not found in global cache. Make sure that Maker API allows this device and restart flows`;
         node.updateStatus('red', errorMsg);
         doneWithId(node, done, errorMsg);
+        return;
+      }
+
+      const attributeSearched = msg.attribute || node.attribute;
+      if (!attributeSearched) {
+        msg.payload = { ...device.attributes };
+        msg.topic = node.topic;
+        send(msg);
+        node.updateStatus();
+        done();
         return;
       }
 

--- a/test/nodes/device_spec.js
+++ b/test/nodes/device_spec.js
@@ -445,7 +445,7 @@ describe('Hubitat Device Node', () => {
       {
         ...defaultDeviceNode,
         deviceId: 1,
-        attribute: 'test',
+        attribute: null,
         wires: [['n2']],
       },
       { id: 'n2', type: 'helper' },


### PR DESCRIPTION
why: It happened only when deviceId was invalid AND msg.attributes was not
set.

note: uncaught exception made node-red crash and stop completely