### PR TITLE
add delay commands option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT
+
+* `config`: Allow to configure a delay between commands
+
 ## 1.9.0 (2023-08-08)
 
 * `command`: A new field `msg.responseStatus` has been added to the response

--- a/nodes/command.js
+++ b/nodes/command.js
@@ -86,7 +86,11 @@ module.exports = function HubitatCommandModule(RED) {
         node.status({ fill: 'red', shape: 'ring', text: err.code });
         done(err);
       } finally {
-        node.hubitat.releaseLock();
+        if (node.hubitat.delayCommands) {
+          setTimeout(() => { node.hubitat.releaseLock(); }, node.hubitat.delayCommands);
+        } else {
+          node.hubitat.releaseLock();
+        }
       }
     });
   }

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -308,6 +308,10 @@
         <input type="checkbox" id="node-config-input-autoRefresh" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
       <div class="form-row">
+        <label for="node-config-input-delayCommands" style="width: auto; margin-right: 5px;">Add delay between commands (ms)</label>
+        <input type="text" id="node-config-input-delayCommands" style="display: inline-block; width: auto; vertical-align: top;">
+      </div>
+      <div class="form-row">
         <label for="node-config-input-useWebsocket" style="width: auto; margin-right: 5px;">Use websocket (<b>not recommended</b>)</label>
         <input type="checkbox" id="node-config-input-useWebsocket" style="display: inline-block; width: auto; vertical-align: top;">
       </div>
@@ -344,6 +348,11 @@
       During the rebuild, if a difference is found between the current Hubitat attribute value and the previous cached value a new event msg for each changed attribute will be sent from the applicable nodes.
       If the current Hubitat attribute value is unchanged from the previous cached value, then no event msg will be sent.
       The <code>systemStart</code> event is triggered any time a Hubitat hub starts up after a power cycle or reboot.
+    </p>
+    <p>
+      <b>Add delay between commands</b> will send commands sequentially with the delay added between commands.
+      When triggering many commands at the same time, some commands may be dropped depending of the mesh and devices used.
+      Sending them sequentially with a delay may help to improve reliability without needed to change flows.
     </p>
     <p>
       <b>Use websocket</b> will switch the internal update mechanism to use Hubitat's websocket instead of webhook.

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -98,6 +98,7 @@
       nodeRedServer: { value: '', validate: validatorNodeRedServer },
       webhookPath: { value: '/hubitat/webhook', validate: validatorWebhookPath },
       autoRefresh: { value: true },
+      delayCommands: { value: '' },
       useWebsocket: { value: false },
       colorEnabled: { value: false },
       color: { value: '#ACE043' },
@@ -353,6 +354,7 @@
       <b>Add delay between commands</b> will send commands sequentially with the delay added between commands.
       When triggering many commands at the same time, some commands may be dropped depending of the mesh and devices used.
       Sending them sequentially with a delay may help to improve reliability without needed to change flows.
+      Note: Using value 0 will send command sequentially without delay. To restore the default parallel behavior, remove the value.
     </p>
     <p>
       <b>Use websocket</b> will switch the internal update mechanism to use Hubitat's websocket instead of webhook.

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -86,6 +86,7 @@ Supported dataType: https://docs.hubitat.com/index.php?title=Attribute_Object`);
     this.nodeRedServer = config.nodeRedServer;
     this.webhookPath = config.webhookPath;
     this.autoRefresh = config.autoRefresh;
+    this.delayCommands = config.delayCommands;
     this.useWebsocket = config.useWebsocket;
     this.wsStatusOk = false;
     this.wsFirstInitPending = true;
@@ -96,7 +97,12 @@ Supported dataType: https://docs.hubitat.com/index.php?title=Attribute_Object`);
     this.expiredDevices = {};
     this.devicesInitialized = false;
 
-    this.requestPool = MAXSIMULTANEOUSREQUESTS;
+    if (this.delayCommands) {
+      this.maxRequestPool = 1;
+    } else {
+      this.maxRequestPool = MAXSIMULTANEOUSREQUESTS;
+    }
+    this.requestPool = this.maxRequestPool;
 
     function sleep(ms) {
       return new Promise((resolve) => { setTimeout(resolve, ms); });
@@ -108,7 +114,7 @@ Supported dataType: https://docs.hubitat.com/index.php?title=Attribute_Object`);
       while (true) {
         if (this.requestPool) {
           this.requestPool -= 1;
-          this.debug(`Lock acquired. Remaining: ${this.requestPool}/${MAXSIMULTANEOUSREQUESTS}`);
+          this.debug(`Lock acquired. Remaining: ${this.requestPool}/${this.maxRequestPool}`);
           return;
         }
         // eslint-disable-next-line no-await-in-loop
@@ -118,7 +124,7 @@ Supported dataType: https://docs.hubitat.com/index.php?title=Attribute_Object`);
 
     this.releaseLock = () => {
       this.requestPool += 1;
-      this.debug(`Lock released. Remaining: ${this.requestPool}/${MAXSIMULTANEOUSREQUESTS}`);
+      this.debug(`Lock released. Remaining: ${this.requestPool}/${this.maxRequestPool}`);
     };
 
     const scheme = ((this.usetls) ? 'https' : 'http');

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -97,11 +97,12 @@ Supported dataType: https://docs.hubitat.com/index.php?title=Attribute_Object`);
     this.expiredDevices = {};
     this.devicesInitialized = false;
 
-    if (this.delayCommands) {
+    if (this.delayCommands) { // value is a string and 0 will be '0' and true
       this.maxRequestPool = 1;
     } else {
       this.maxRequestPool = MAXSIMULTANEOUSREQUESTS;
     }
+    this.debug(`Setting maximum concurrent requests to ${this.maxRequestPool}`);
     this.requestPool = this.maxRequestPool;
 
     function sleep(ms) {


### PR DESCRIPTION
Add delay commands option in the Advanced tab from Config node.

It will send commands sequentially with the delay added between commands.
When triggering many commands at the same time, some commands may be dropped depending of the mesh and devices used.
Sending them sequentially with a delay may help to improve reliability without needed to change flows.

`<TODO add image>`