### PR TITLE
Add switch-logic, capture, and restore nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,17 @@ npm install node-red-contrib-hubitat
 * `location`: To receive global location events (ex: systemStart, sunrise, sunset)
 * `event`: A generic node to receive all events.
 * `request`: A generic node to request any Hubitat's endpoints.
-
+* `capture`: To persist the current state of selected Hubitat devices into Node-RED flow context so they can be restored later. 
+* `restore`: Retrieves previously captured device states from flow context and sends commands to return devices to their saved state.
+* `logic`: The **logic** node can be used as a logic gate or as a trigger for one or more contact, lock, motion, presence, or switch devices.
 * `config`: To setup Hubitat connection information. It also listen for webhook from Hubitat
   to dispatch events to other nodes.
 
 **Note**: `config` node is a configuration node type, which means that it cannot be used directly,
 but used by other nodes.
+
+See the `examples/` folder for importable Node-RED flows demonstrating these nodes in action.
+
 
 ## Documentation
 

--- a/nodes/capture.html
+++ b/nodes/capture.html
@@ -1,3 +1,14 @@
+</script>
+
+<script type="text/x-red" data-help-name="hubitat capture">
+<p><b>Capture Node</b></p>
+<ul>
+  <li><b>Name</b>: Custom name for this node instance.</li>
+  <li><b>Hub</b>: Select the Hubitat hub to connect to.</li>
+  <li><b>Devices</b>: Choose one or more devices whose state will be captured and stored in flow context.</li>
+  <li><b>Clear data on edit/restart</b>: If checked, all stored states owned by this node will be cleared when the node is edited, redeployed, or Node-RED restarts.</li>
+</ul>
+</script>
 <script type="text/javascript">
 (function () {
   let currentRequestId = 0;
@@ -59,7 +70,8 @@
     defaults: {
       name: { value: '' },
       server: { type: 'hubitat config', required: true },
-      deviceId: { value: [] }
+      deviceId: { value: [] },
+      clearOnEditRestart: { value: false }
     },
     inputs: 1,
     outputs: 1,
@@ -104,6 +116,7 @@
     oneditsave() {
       const selected = $('#node-input-deviceId').val() || [];
       this.deviceId = Array.isArray(selected) ? selected : [selected];
+      this.clearOnEditRestart = $('#node-input-clearOnEditRestart').prop('checked');
 
       if (this.deviceId.length > 0) {
         updateNameWithCount(this, { force: true });
@@ -142,5 +155,12 @@
   <div class="form-row">
     <label for="node-input-deviceId"><i class="fa fa-toggle-on"></i> Devices</label>
     <select id="node-input-deviceId" multiple size="8" style="width:100%;"></select>
+  </div>
+  <div class="form-row">
+    <label>&nbsp;</label>
+    <label style="white-space:nowrap; vertical-align:middle;">
+      <input type="checkbox" id="node-input-clearOnEditRestart" style="vertical-align:middle; margin-top:-2px;">
+      <span style="vertical-align:middle; margin-left:6px;">Clear data on edit/restart</span>
+    </label>
   </div>
 </script>

--- a/nodes/capture.html
+++ b/nodes/capture.html
@@ -1,0 +1,146 @@
+<script type="text/javascript">
+(function () {
+  let currentRequestId = 0;
+
+  function listSwitchDevices(server, selectedIds, requestId) {
+    const selectMenu = $('#node-input-deviceId');
+    selectMenu.empty();
+
+    $.getJSON('hubitat/devices/all', paramsFromServer(server))
+      .done((res) => {
+        if (requestId !== currentRequestId) return;
+        if (!Array.isArray(res)) {
+          console.warn("hubitat/devices/all returned non-array:", res);
+          return;
+        }
+
+        const deviceId = res.filter((device) => {
+          const hasCapability = Array.isArray(device.capabilities) && device.capabilities.includes('Switch');
+          const hasSwitchAttr = (
+            device.attributes &&
+            device.attributes.switch !== undefined &&
+            device.attributes.switch !== null
+          );
+          return hasCapability || hasSwitchAttr;
+        });
+
+        deviceId.sort((a, b) => {
+          const la = (a.label || a.name || a.id).toString().toLowerCase();
+          const lb = (b.label || b.name || b.id).toString().toLowerCase();
+          return la.localeCompare(lb);
+        });
+
+        deviceId.forEach((device) => {
+          const val = String(device.id);
+          if (selectMenu.find(`option[value="${val}"]`).length === 0) {
+            const option = $('<option>', {
+              value: val,
+              text: device.label || device.name || device.id
+            });
+            if (selectedIds && selectedIds.map(String).includes(val)) {
+              option.prop('selected', true);
+            }
+            selectMenu.append(option);
+          }
+        });
+
+        if (typeof selectMenu.data('initialized') === 'undefined') {
+          selectMenu.data('initialized', true);
+        }
+      })
+      .fail((jqXHR, textStatus, errorThrown) => {
+        console.error("hubitat/devices/all request failed:", textStatus, errorThrown);
+      });
+  }
+
+  RED.nodes.registerType('hubitat capture', {
+    category: 'hubitat',
+    color: '#ACE043',
+    defaults: {
+      name: { value: '' },
+      server: { type: 'hubitat config', required: true },
+      deviceId: { value: [] }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'font-awesome/fa-camera',
+    label() { return this.name || 'capture'; },
+    paletteLabel: 'capture',
+
+    oneditprepare() {
+      const node = this;
+      let initialized = false;
+
+      function refreshDeviceList() {
+        const serverId = $('#node-input-server option:selected').val();
+        const server = RED.nodes.node(serverId);
+
+        currentRequestId += 1;
+        const requestId = currentRequestId;
+        $('#node-input-deviceId').empty();
+
+        if (server) {
+          loadCredentials(server).then(() => {
+            listSwitchDevices(server, node.deviceId, requestId);
+            initialized = true; // now user changes can trigger updates
+          }).catch(() => {
+            $('#node-input-deviceId').empty();
+          });
+        } else {
+          cleanHubitatDevices();
+        }
+      }
+
+      $('#node-input-server').off('change').on('change', refreshDeviceList);
+      $('#node-input-deviceId').empty();
+      refreshDeviceList();
+
+      // Only update name when device selection changes by user
+      $('#node-input-deviceId').off('.count').on('change.count', function () {
+        if (initialized) updateNameWithCount(node);
+      });
+    },
+
+    oneditsave() {
+      const selected = $('#node-input-deviceId').val() || [];
+      this.deviceId = Array.isArray(selected) ? selected : [selected];
+
+      if (this.deviceId.length > 0) {
+        updateNameWithCount(this, { force: true });
+      }
+    }
+  });
+
+  function updateNameWithCount(node, opts) {
+    opts = opts || {};
+    const sel = $('#node-input-deviceId').val();
+    if (!sel || sel.length === 0) return;
+
+    const chosen = Array.isArray(sel) ? sel : [sel];
+    const count = chosen.length;
+
+    let base = $('#node-input-name').val() || (node && node.name) || 'capture';
+    base = base.replace(/\s*\(\d+\)$/, '');
+
+    $('#node-input-name').val(base + ' (' + count + ')');
+    return count;
+  }
+})();
+</script>
+
+<script type="text/x-red" data-template-name="hubitat capture">
+  <div class="form-row">
+    <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-server"><i class="fa fa-globe"></i> Hub</label>
+    <input type="text" id="node-input-server">
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-deviceId"><i class="fa fa-toggle-on"></i> Devices</label>
+    <select id="node-input-deviceId" multiple size="8" style="width:100%;"></select>
+  </div>
+</script>

--- a/nodes/capture.js
+++ b/nodes/capture.js
@@ -1,0 +1,147 @@
+module.exports = function HubitatCaptureModule(RED) {
+  function HubitatCaptureNode(config) {
+    RED.nodes.createNode(this, config);
+
+    const node = this;
+    node.hubitat = RED.nodes.getNode(config.server);
+
+
+    const count = Array.isArray(config.deviceId) ? config.deviceId.length : 0;
+    const base = config.name && config.name.trim().length ? config.name : "capture";
+    node.name = `${base} (${count})`;
+
+
+    if (!node.hubitat) {
+      node.error('Hubitat server not configured');
+      return;
+    }
+
+    // normalize configured device list
+    function configuredDeviceList() {
+      return Array.isArray(config.deviceId) ? config.deviceId.slice() : [];
+    }
+
+    async function refreshDeviceMap(force = false) {
+      if (!node.hubitat) return;
+      if (typeof node.hubitat.devicesFetcher !== 'function') {
+        node.log('hubitat-capture: devicesFetcher() is not available on hubitat config node');
+        return;
+      }
+
+      if (force) {
+        try {
+          node.hubitat.devicesInitialized = false;
+        } catch (e) {}
+      }
+
+      try {
+        await node.hubitat.devicesFetcher();
+      } catch (e) {
+        node.log(`hubitat-capture: devicesFetcher() threw: ${e?.message || e}`);
+      }
+    }
+
+    function findDevice(deviceId, devicesMap) {
+      if (!devicesMap) return undefined;
+
+      if (Object.prototype.hasOwnProperty.call(devicesMap, deviceId)) {
+        return devicesMap[deviceId];
+      }
+
+      const numId = Number(deviceId);
+      if (!isNaN(numId) && Object.prototype.hasOwnProperty.call(devicesMap, numId)) {
+        return devicesMap[numId];
+      }
+
+      const values = Object.values(devicesMap || {});
+      for (let i = 0; i < values.length; i++) {
+        const d = values[i];
+        if (!d) continue;
+        if (String(d.id) === String(deviceId) || String(d.deviceId) === String(deviceId)
+            || String(d.name) === String(deviceId) || String(d.label) === String(deviceId)) {
+          return d;
+        }
+      }
+      return undefined;
+    }
+
+    const ATTRS = [
+      "switch", "level", "color", "hue", "RGB",
+      "colorTemperature", "saturation", "colorMode", "colorName"
+    ];
+
+    node.on("input", async function (msg, send, done) {
+      try {
+        const toCapture = configuredDeviceList();
+        if (!Array.isArray(toCapture) || toCapture.length === 0) {
+          node.warn("No devices selected");
+          send(msg);
+          if (done) done();
+          return;
+        }
+
+        await refreshDeviceMap(true);
+
+        const devicesMap = node.hubitat.devices || {};
+        const flowContext = node.context().flow;
+        const summaries = [];
+
+        await Promise.all(toCapture.map(async (rawId) => {
+          const deviceId = (rawId && typeof rawId === 'object' && (rawId.id || rawId.deviceId)) ? (rawId.id || rawId.deviceId) : rawId;
+          const device = findDevice(deviceId, devicesMap);
+          if (!device) {
+            return;
+          }
+
+          const captured = { id: device.id, name: device.label || device.name || "", owner: node.id };
+          ATTRS.forEach(attr => {
+            const attrs = device.attributes || {};
+            const found = attrs[attr] || attrs[attr.toLowerCase()];
+            if (found && typeof found.value !== "undefined") {
+              captured[attr] = found.value;
+            } else if (found && typeof found.currentValue !== "undefined") {
+              captured[attr] = found.currentValue;
+            } else if (typeof device[attr] !== "undefined") {
+              captured[attr] = device[attr];
+            }
+          });
+
+          flowContext.set(`hubitat_device_state_${device.id}`, captured);
+          summaries.push({ id: device.id, name: captured.name });
+        }));
+
+        send({ payload: summaries });
+        if (done) done();
+      } catch (err) {
+        node.error(`Error capturing devices: ${err?.message || err}`, msg);
+        if (done) done(err);
+      }
+    });
+
+    node.on("close", async function (removed, done) {
+      try {
+        await refreshDeviceMap(true);
+
+        const flowContext = node.context().flow;
+        const cleanup = configuredDeviceList();
+        if (Array.isArray(cleanup)) {
+          cleanup.forEach(raw => {
+            const id = (raw && typeof raw === 'object' && (raw.id || raw.deviceId)) ? (raw.id || raw.deviceId) : raw;
+            const key = `hubitat_device_state_${id}`;
+            const existing = flowContext.get(key);
+            if (existing && existing.owner === node.id) {
+              flowContext.set(key, undefined);
+            }
+          });
+        }
+
+        done();
+      } catch (err) {
+        node.error(`Error during close cleanup: ${err?.message || err}`);
+        done();
+      }
+    });
+  }
+
+  RED.nodes.registerType("hubitat capture", HubitatCaptureNode);
+};

--- a/nodes/logic.html
+++ b/nodes/logic.html
@@ -1,3 +1,15 @@
+<script type="text/x-red" data-help-name="hubitat logic">
+<p><b>Logic Node</b></p>
+<ul>
+  <li><b>Name</b>: Custom name for this node instance.</li>
+  <li><b>Hub</b>: Select the Hubitat hub to connect to.</li>
+  <li><b>Device Type</b>: Choose the type of device to evaluate (Switch, Motion, Lock, Contact, Presence).</li>
+  <li><b>Devices</b>: Choose one or more devices to evaluate.</li>
+  <li><b>Target Value</b>: The value to compare against device states (e.g., On/Off, Active/Inactive).</li>
+  <li><b>Mode</b>: 'All' requires all devices to match the target value; 'Any' requires at least one device to match.</li>
+  <li><b>Send events</b>: If checked, the node will send events when the logic condition is met.</li>
+</ul>
+</script>
 <script type="text/javascript">
 (function () {
   let currentRequestId = 0;

--- a/nodes/logic.html
+++ b/nodes/logic.html
@@ -1,0 +1,221 @@
+<script type="text/javascript">
+(function () {
+  let currentRequestId = 0;
+
+  const DEVICE_TYPES = [
+    { value: 'contact', label: 'Contact' },
+    { value: 'lock', label: 'Lock' },
+    { value: 'motion', label: 'Motion' },
+    { value: 'presence', label: 'Presence' },
+    { value: 'switch', label: 'Switch' }
+  ];
+
+  const TARGET_VALUES = {
+    switch: [
+      { value: 'on', label: 'On' },
+      { value: 'off', label: 'Off' }
+    ],
+    motion: [
+      { value: 'active', label: 'Active' },
+      { value: 'inactive', label: 'Inactive' }
+    ],
+    lock: [
+      { value: 'locked', label: 'Locked' },
+      { value: 'unlocked', label: 'Unlocked' },
+      { value: 'unlocked with timeout', label: 'Unlocked with Timeout' },
+      { value: 'unknown', label: 'Unknown' }
+    ],
+    contact: [
+      { value: 'open', label: 'Open' },
+      { value: 'closed', label: 'Closed' }
+    ],
+    presence: [
+      { value: 'present', label: 'Present' },
+      { value: 'not present', label: 'Not Present' }
+    ]
+  };
+
+  function listDevices(server, deviceType, selectedIds, requestId) {
+    const selectMenu = $('#node-input-deviceId');
+    selectMenu.empty();
+    if (!server || !deviceType) return;
+    $.getJSON('hubitat/devices/all', paramsFromServer(server))
+      .done((res) => {
+        if (requestId !== currentRequestId) return;
+        if (!Array.isArray(res)) {
+          console.warn("hubitat/devices/all returned non-array:", res);
+          return;
+        }
+        const capabilityMap = {
+          switch: 'Switch',
+          presence: 'PresenceSensor',
+          motion: 'MotionSensor',
+          lock: 'Lock',
+          contact: 'ContactSensor'
+        };
+        const filtered = res.filter((device) => {
+          const cap = capabilityMap[deviceType];
+          return Array.isArray(device.capabilities) && device.capabilities.includes(cap);
+        });
+        filtered.sort((a, b) => {
+          const la = (a.label || a.name || a.id).toString().toLowerCase();
+          const lb = (b.label || b.name || b.id).toString().toLowerCase();
+          return la.localeCompare(lb);
+        });
+        filtered.forEach((device) => {
+          const val = String(device.id);
+          if (selectMenu.find(`option[value="${val}"]`).length === 0) {
+            const option = $('<option>', {
+              value: val,
+              text: device.label || device.name || device.id
+            });
+            if (selectedIds && selectedIds.map(String).includes(val)) {
+              option.prop('selected', true);
+            }
+            selectMenu.append(option);
+          }
+        });
+        if (typeof selectMenu.data('initialized') === 'undefined') {
+          selectMenu.data('initialized', true);
+        }
+      })
+      .fail((jqXHR, textStatus, errorThrown) => {
+        console.error("hubitat/devices/all request failed:", textStatus, errorThrown);
+      });
+  }
+
+  function updateTargetValues(deviceType, selectedValue) {
+    const selectMenu = $('#node-input-targetValue');
+    selectMenu.empty();
+    if (!deviceType || !TARGET_VALUES[deviceType]) return;
+    TARGET_VALUES[deviceType].forEach(opt => {
+      const option = $('<option>', {
+        value: opt.value,
+        text: opt.label
+      });
+      if (selectedValue === opt.value) {
+        option.prop('selected', true);
+      }
+      selectMenu.append(option);
+    });
+  }
+
+  RED.nodes.registerType('hubitat logic', {
+    category: 'hubitat',
+    color: '#ACE043',
+    defaults: {
+      name: { value: '' },
+      server: { type: 'hubitat config', required: true },
+      deviceType: { value: '' },
+      deviceId: { value: [] },
+      targetValue: { value: '' },
+      mode: { value: 'all' },
+      sendEvents: { value: false }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'font-awesome/fa-gears',
+    label() { return this.name || 'logic'; },
+    paletteLabel: 'logic',
+
+    oneditprepare() {
+      const node = this;
+      let initialized = false;
+      // Populate device type dropdown
+      const deviceTypeMenu = $('#node-input-deviceType');
+      deviceTypeMenu.empty();
+      DEVICE_TYPES.forEach(type => {
+        deviceTypeMenu.append($('<option>', { value: type.value, text: type.label }));
+      });
+      if (node.deviceType) {
+        deviceTypeMenu.val(node.deviceType);
+      }
+      function refreshDeviceList() {
+        const serverId = $('#node-input-server option:selected').val();
+        const server = RED.nodes.node(serverId);
+        const deviceType = $('#node-input-deviceType').val();
+        currentRequestId += 1;
+        const requestId = currentRequestId;
+        $('#node-input-deviceId').empty();
+        if (server && deviceType) {
+          loadCredentials(server).then(() => {
+            listDevices(server, deviceType, node.deviceId, requestId);
+            updateTargetValues(deviceType, node.targetValue);
+            initialized = true;
+          }).catch(() => {
+            $('#node-input-deviceId').empty();
+            updateTargetValues(deviceType, node.targetValue);
+          });
+        } else {
+          $('#node-input-deviceId').empty();
+          updateTargetValues(deviceType, node.targetValue);
+        }
+      }
+      $('#node-input-server').off('change').on('change', refreshDeviceList);
+      $('#node-input-deviceType').off('change').on('change', refreshDeviceList);
+      $('#node-input-deviceId').empty();
+      refreshDeviceList();
+      $('#node-input-deviceId').off('.count').on('change.count', function () {
+        if (initialized) updateNameWithCount(node);
+      });
+    },
+    oneditsave() {
+      const selected = $('#node-input-deviceId').val() || [];
+      this.deviceId = Array.isArray(selected) ? selected : [selected];
+      this.deviceType = $('#node-input-deviceType').val();
+      this.targetValue = $('#node-input-targetValue').val();
+      this.mode = $('#node-input-mode').val();
+      this.sendEvents = $('#node-input-sendEvents').prop('checked');
+      if (this.deviceId.length > 0) {
+        updateNameWithCount(this, { force: true });
+      }
+    }
+  });
+
+  function updateNameWithCount(node, opts) {
+  opts = opts || {};
+  const sel = $('#node-input-deviceId').val();
+  if (!sel || sel.length === 0) return;
+  const chosen = Array.isArray(sel) ? sel : [sel];
+  const count = chosen.length;
+  let base = $('#node-input-name').val() || (node && node.name) || 'logic';
+  base = base.replace(/\s*\(\d+\)$/, '');
+  $('#node-input-name').val(base + ' (' + count + ')');
+  return count;
+  }
+})();
+</script>
+
+<script type="text/x-red" data-template-name="hubitat logic">
+  <div class="form-row">
+    <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+  <div class="form-row">
+    <label for="node-input-server"><i class="fa fa-globe"></i> Hub</label>
+    <select id="node-input-server"></select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-deviceType"><i class="fa fa-list"></i> Device Type</label>
+    <select id="node-input-deviceType"></select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-deviceId"><i class="fa fa-toggle-on"></i> Devices</label>
+    <select id="node-input-deviceId" multiple size="8" style="width:100%;"></select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-targetValue"><i class="fa fa-bullseye"></i> Target Value</label>
+    <select id="node-input-targetValue"></select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-mode"><i class="fa fa-sliders"></i> Mode</label>
+    <select id="node-input-mode">
+      <option value="all">All</option>
+      <option value="any">Any</option>
+    </select>
+  </div>
+  <div class="form-row">
+    <label for="node-input-sendEvents"><i class="fa fa-bell"></i> Send events</label>
+    <input type="checkbox" id="node-input-sendEvents">
+  </div>
+</script>

--- a/nodes/logic.js
+++ b/nodes/logic.js
@@ -1,0 +1,216 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable global-require */
+module.exports = function HubitatLogicModule(RED) {
+  const doneWithId = require('./utils/done-with-id');
+
+  function HubitatLogicNode(config) {
+    RED.nodes.createNode(this, config);
+    this.hubitat = RED.nodes.getNode(config.server);
+    this.name = config.name;
+    this.deviceType = config.deviceType;
+    this.deviceId = config.deviceId;
+    this.targetValue = config.targetValue;
+    this.mode = config.mode;
+    this.sendEvents = config.sendEvents;
+    this.shape = this.sendEvents ? 'dot' : 'ring';
+    this.currentStatusText = '';
+    this.currentStatusFill = undefined;
+    this.wsState = '';
+    this.topic = this.name;
+    const node = this;
+
+    if (!node.hubitat) {
+      node.error('Hubitat server not configured');
+      return;
+    }
+
+    let logicState = null;
+    let lastFlip = null;
+    this.updateStatus = () => {
+      let stateText;
+      if (logicState === null) {
+        stateText = 'waiting for events';
+      } else {
+        const modeText = node.mode || '';
+        const targetText = node.targetValue || '';
+        const resultText = logicState ? 'TRUE' : 'FALSE';
+        const stamp = lastFlip ? lastFlip.toLocaleString() : '';
+        stateText = `${modeText} ${targetText} ${resultText}${stamp ? ' ' + stamp : ''}`.trim();
+      }
+      node.status({
+        fill: logicState ? 'green' : 'grey',
+        shape: node.sendEvents ? 'dot' : 'ring',
+        text: stateText
+      });
+    };
+
+    async function initializeDevices() {
+      try {
+        await node.hubitat.devicesFetcher();
+      } catch (err) {
+        node.warn(`Unable to initialize devices: ${err.message}`);
+        node.updateStatus('red', 'Uninitialized');
+        throw err;
+      }
+    }
+
+    function getDeviceState(deviceId) {
+      const device = node.hubitat.devices[deviceId];
+      if (!device) return null;
+      // Map deviceType to attribute name
+      const attrMap = {
+        switch: 'switch',
+        motion: 'motion',
+        lock: 'lock',
+        contact: 'contact',
+        presence: 'presence'
+      };
+      const attr = attrMap[node.deviceType];
+      if (!attr) return null;
+      let attribute = null;
+      if (Array.isArray(device.attributes)) {
+        attribute = device.attributes.find(a => a && a.name === attr);
+      } else {
+        attribute = device.attributes[attr];
+      }
+      if (!attribute) return null;
+      if (typeof attribute === 'object' && attribute.currentValue !== undefined) {
+        return attribute.currentValue;
+      }
+      return attribute.value !== undefined ? attribute.value : attribute;
+    }
+
+    function matchesTargetValue(state) {
+      if (state == null) return false;
+      // For lock, handle 'unlocked with timeout' and 'unknown'
+      if (node.deviceType === 'lock') {
+        if (node.targetValue === 'unlocked with timeout') {
+          return state === 'unlocked with timeout';
+        }
+        if (node.targetValue === 'unknown') {
+          return state === 'unknown';
+        }
+      }
+      return state === node.targetValue;
+    }
+
+    function computeLogicState() {
+      if (!node.deviceId || node.deviceId.length === 0) return false;
+      const desired = node.targetValue;
+      const values = node.deviceId.map(id => getDeviceState(id));
+      if (node.mode === 'all') {
+        return values.length > 0 && values.every(v => v === desired);
+      } else {
+        return values.some(v => v === desired);
+      }
+    }
+
+    const eventCallback = async (event) => {
+      node.debug(`Event received: ${JSON.stringify(event)}`);
+      if (node.hubitat.devicesInitialized !== true) {
+        try {
+          await initializeDevices();
+        } catch (err) {
+          return;
+        }
+      }
+      if (!node.deviceId.includes(event.deviceId)) return;
+      // Update device state and compute logic
+      const state = getDeviceState(event.deviceId);
+      const newState = computeLogicState();
+      if (newState !== logicState) {
+        logicState = newState;
+        lastFlip = new Date();
+        node.updateStatus();
+        if (logicState && node.sendEvents) {
+          node.send({ payload: { ...event, state }, topic: node.topic });
+        }
+      } else {
+        node.updateStatus();
+      }
+    };
+
+    const systemStartCallback = async () => {
+      try {
+        await initializeDevices();
+      } catch (err) {
+        return;
+      }
+      node.updateStatus();
+    };
+
+    if (Array.isArray(node.deviceId)) {
+      node.deviceId.forEach(id => {
+        node.hubitat.hubitatEvent.on(`device.${id}`, eventCallback);
+      });
+      node.hubitat.hubitatEvent.on('systemStart', systemStartCallback);
+    }
+
+    const wsOpened = async () => {
+      node.updateStatus(node.currentStatusFill, node.currentStatusText);
+    };
+    node.hubitat.hubitatEvent.on('websocket-opened', wsOpened);
+    const wsClosed = async () => {
+      node.updateStatus(node.currentStatusFill, node.currentStatusText);
+    };
+    node.hubitat.hubitatEvent.on('websocket-closed', wsClosed);
+    node.hubitat.hubitatEvent.on('websocket-error', wsClosed);
+
+    (async () => {
+      try {
+        await initializeDevices();
+      } catch (err) {
+        node.warn(`Initialization error: ${err && err.message ? err.message : err}`);
+      }
+      // Compute initial state and update status after deploy
+      logicState = computeLogicState();
+      node.updateStatus();
+    })();
+
+    node.on('input', async (msg, send, done) => {
+      node.debug('Input received');
+      if (node.hubitat.devicesInitialized !== true) {
+        try {
+          await initializeDevices();
+        } catch (err) {
+          return;
+        }
+      }
+      const deviceIds = ((msg.deviceId !== undefined) ? msg.deviceId : node.deviceId);
+      if (!deviceIds || deviceIds.length === 0) {
+        const errorMsg = 'Undefined device ID(s)';
+        node.updateStatus();
+        doneWithId(node, done, errorMsg);
+        return;
+      }
+      const states = deviceIds.map(id => getDeviceState(id));
+      const newState = computeLogicState();
+      if (newState !== logicState) {
+        logicState = newState;
+        lastFlip = new Date();
+      }
+      node.updateStatus();
+      if (logicState) {
+        send(msg);
+      } else {
+        send(null);
+      }
+      done();
+    });
+
+    node.on('close', () => {
+      node.debug('Closed');
+      if (Array.isArray(node.deviceId)) {
+        node.deviceId.forEach(id => {
+          node.hubitat.hubitatEvent.removeListener(`device.${id}`, eventCallback);
+        });
+        node.hubitat.hubitatEvent.removeListener('systemStart', systemStartCallback);
+      }
+      node.hubitat.hubitatEvent.removeListener('websocket-opened', wsOpened);
+      node.hubitat.hubitatEvent.removeListener('websocket-closed', wsClosed);
+      node.hubitat.hubitatEvent.removeListener('websocket-error', wsClosed);
+    });
+  }
+
+  RED.nodes.registerType('hubitat logic', HubitatLogicNode);
+};

--- a/nodes/logic.js
+++ b/nodes/logic.js
@@ -96,12 +96,11 @@ module.exports = function HubitatLogicModule(RED) {
 
     function computeLogicState() {
       if (!node.deviceId || node.deviceId.length === 0) return false;
-      const desired = node.targetValue;
       const values = node.deviceId.map(id => getDeviceState(id));
       if (node.mode === 'all') {
-        return values.length > 0 && values.every(v => v === desired);
+        return values.length > 0 && values.every(v => matchesTargetValue(v));
       } else {
-        return values.some(v => v === desired);
+        return values.some(v => matchesTargetValue(v));
       }
     }
 

--- a/nodes/restore.html
+++ b/nodes/restore.html
@@ -1,3 +1,23 @@
+</script>
+
+<script type="text/x-red" data-help-name="hubitat restore">
+<p><b>Restore Node</b></p>
+<ul>
+  <li><b>Name</b>: Custom name for this node instance.</li>
+  <li><b>Hub</b>: Select the Hubitat hub to connect to.</li>
+  <li><b>Devices</b>: Choose one or more devices to restore to their previously captured state from flow context.</li>
+</ul>
+</script>
+</script>
+
+<script type="text/x-red" data-help-name="hubitat restore">
+<p><b>Restore Node</b></p>
+<ul>
+  <li><b>Name</b>: Custom name for this node instance.</li>
+  <li><b>Hub</b>: Select the Hubitat hub to connect to.</li>
+  <li><b>Devices</b>: Choose one or more devices to restore to their previously captured state from flow context.</li>
+</ul>
+</script>
 <script type="text/javascript">
 (function () {
   let currentRequestId = 0;

--- a/nodes/restore.html
+++ b/nodes/restore.html
@@ -1,0 +1,146 @@
+<script type="text/javascript">
+(function () {
+  let currentRequestId = 0;
+
+  function listSwitchDevices(server, selectedIds, requestId) {
+    const selectMenu = $('#node-input-deviceId');
+    selectMenu.empty();
+
+    $.getJSON('hubitat/devices/all', paramsFromServer(server))
+      .done((res) => {
+        if (requestId !== currentRequestId) return;
+        if (!Array.isArray(res)) {
+          console.warn("hubitat/devices/all returned non-array:", res);
+          return;
+        }
+
+        const deviceId = res.filter((device) => {
+          const hasCapability = Array.isArray(device.capabilities) && device.capabilities.includes('Switch');
+          const hasSwitchAttr = (
+            device.attributes &&
+            device.attributes.switch !== undefined &&
+            device.attributes.switch !== null
+          );
+          return hasCapability || hasSwitchAttr;
+        });
+
+        deviceId.sort((a, b) => {
+          const la = (a.label || a.name || a.id).toString().toLowerCase();
+          const lb = (b.label || b.name || b.id).toString().toLowerCase();
+          return la.localeCompare(lb);
+        });
+
+        deviceId.forEach((device) => {
+          const val = String(device.id);
+          if (selectMenu.find(`option[value="${val}"]`).length === 0) {
+            const option = $('<option>', {
+              value: val,
+              text: device.label || device.name || device.id
+            });
+            if (selectedIds && selectedIds.map(String).includes(val)) {
+              option.prop('selected', true);
+            }
+            selectMenu.append(option);
+          }
+        });
+
+        if (typeof selectMenu.data('initialized') === 'undefined') {
+          selectMenu.data('initialized', true);
+        }
+      })
+      .fail((jqXHR, textStatus, errorThrown) => {
+        console.error("hubitat/devices/all request failed:", textStatus, errorThrown);
+      });
+  }
+
+  RED.nodes.registerType('hubitat restore', {
+    category: 'hubitat',
+    color: '#ACE043',
+    defaults: {
+      name: { value: '' },
+      server: { type: 'hubitat config', required: true },
+      deviceId: { value: [] }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'font-awesome/fa-undo',
+    label() { return this.name || 'restore'; },
+    paletteLabel: 'restore',
+
+    oneditprepare() {
+      const node = this;
+      let initialized = false;
+
+      function refreshDeviceList() {
+        const serverId = $('#node-input-server option:selected').val();
+        const server = RED.nodes.node(serverId);
+
+        currentRequestId += 1;
+        const requestId = currentRequestId;
+        $('#node-input-deviceId').empty();
+
+        if (server) {
+          loadCredentials(server).then(() => {
+            listSwitchDevices(server, node.deviceId, requestId);
+            initialized = true; // now user changes trigger updates
+          }).catch(() => {
+            $('#node-input-deviceId').empty();
+          });
+        } else {
+          cleanHubitatDevices();
+        }
+      }
+
+      $('#node-input-server').off('change').on('change', refreshDeviceList);
+      $('#node-input-deviceId').empty();
+      refreshDeviceList();
+
+      // Only update name when device selection changes by user
+      $('#node-input-deviceId').off('.count').on('change.count', function () {
+        if (initialized) updateNameWithCount(node);
+      });
+    },
+
+    oneditsave() {
+      const selected = $('#node-input-deviceId').val() || [];
+      this.deviceId = Array.isArray(selected) ? selected : [selected];
+
+      if (this.deviceId.length > 0) {
+        updateNameWithCount(this, { force: true });
+      }
+    }
+  });
+
+  function updateNameWithCount(node, opts) {
+    opts = opts || {};
+    const sel = $('#node-input-deviceId').val();
+    if (!sel || sel.length === 0) return;
+
+    const chosen = Array.isArray(sel) ? sel : [sel];
+    const count = chosen.length;
+
+    let base = $('#node-input-name').val() || (node && node.name) || 'restore';
+    base = base.replace(/\s*\(\d+\)$/, '');
+
+    $('#node-input-name').val(base + ' (' + count + ')');
+    return count;
+  }
+})();
+</script>
+
+<script type="text/x-red" data-template-name="hubitat restore">
+  <div class="form-row">
+    <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-server"><i class="fa fa-globe"></i> Hub</label>
+    <input type="text" id="node-input-server">
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-deviceId"><i class="fa fa-toggle-on"></i> Devices</label>
+    <select id="node-input-deviceId" multiple size="8" style="width:100%;"></select>
+  </div>
+</script>

--- a/nodes/restore.js
+++ b/nodes/restore.js
@@ -1,0 +1,182 @@
+module.exports = function HubitatRestoreModule(RED) {
+  const fetch = require("node-fetch");
+  const doneWithId = require("./utils/done-with-id");
+
+  function HubitatRestoreNode(config) {
+    RED.nodes.createNode(this, config);
+
+    const node = this;
+    node.hubitat = RED.nodes.getNode(config.server);
+    node.name = config.name;
+
+    function configuredDeviceList() {
+      if (Array.isArray(config.devices) && config.devices.length) return config.devices.slice();
+      if (config.deviceId) return Array.isArray(config.deviceId) ? config.deviceId.slice() : [config.deviceId];
+      return [];
+    }
+
+    node.devices = configuredDeviceList();
+
+    if (!node.hubitat) {
+      node.error("Hubitat server not configured");
+      return;
+    }
+
+    node.on("input", async function (msg, send, done) {
+      try {
+        const toRestore = configuredDeviceList();
+        if (!Array.isArray(toRestore) || toRestore.length === 0) {
+          node.warn("No devices selected");
+          send(msg);
+          if (done) done();
+          return;
+        }
+
+        const flowContext = node.context().flow;
+
+        await Promise.all(toRestore.map(async (deviceId) => {
+          const key = `hubitat_device_state_${deviceId}`;
+          const state = flowContext.get(key);
+
+          if (!state) {
+            node.warn(`No saved state for ${deviceId}`);
+            return;
+          }
+
+          let commands = [];
+
+          // Switch-only devices
+          if (state.switch !== undefined && state.level === undefined && state.colorMode === undefined) {
+            commands.push({ deviceId, command: state.switch });
+          }
+
+          // Dimmers (switch + level)
+          if (state.level !== undefined && state.colorMode === undefined) {
+            if (state.switch === "off") {
+              commands.push({ deviceId, command: "off" });
+            } else {
+              commands.push({ deviceId, command: "on" });
+              commands.push({ deviceId, command: "setLevel", arguments: [state.level] });
+            }
+          }
+
+          // Color bulbs
+          if (state.colorMode !== undefined) {
+            if (state.switch === "off") {
+              commands.push({ deviceId, command: "off" });
+            } else if (state.switch === "on") {
+              if (state.colorMode === "CT" && state.colorTemperature !== undefined) {
+                commands.push({
+                  deviceId,
+                  command: "setColorTemperature",
+                  arguments: [state.colorTemperature, state.level]
+                });
+              } else if (state.colorMode === "RGB" && state.hue !== undefined && state.saturation !== undefined) {
+                commands.push({
+                  deviceId,
+                  command: "setColor",
+                  arguments: [{
+                    hue: state.hue,
+                    saturation: state.saturation,
+                    level: state.level
+                  }]
+                });
+              }
+            }
+          }
+
+          // cleanup after restore
+          flowContext.set(key, undefined);
+
+          // update node status
+          const now = new Date();
+          const formattedTime = now.toLocaleString();
+          node.status({ fill: "green", shape: "dot", text: `restored ${state.name || deviceId} ${formattedTime}` });
+
+
+            // execute each command directly (command.js logic inlined)
+            for (const cmd of commands) {
+              let deviceId = String(cmd.deviceId);
+              let command = String(cmd.command);
+              let commandArgs =
+                cmd.arguments && cmd.arguments.length
+                  ? JSON.stringify(
+                      cmd.arguments.reduce((acc, cur) => {
+                        if (typeof cur === "object" && !Array.isArray(cur)) {
+                          return { ...acc, ...cur };
+                        }
+                        return acc;
+                      }, {})
+                    )
+                  : "";
+
+              let commandWithArgs = command;
+              if (commandArgs) {
+                commandWithArgs = `${command}/${encodeURIComponent(commandArgs)}`;
+              }
+
+              const baseUrl = `${node.hubitat.baseUrl}/devices/${deviceId}/${commandWithArgs}`;
+              const url = `${baseUrl}?access_token=${node.hubitat.token}`;
+              const options = { method: "GET" };
+
+              try {
+                await node.hubitat.acquireLock();
+                const output = {
+                  ...msg,
+                  deviceId,
+                  command,
+                  requestArguments: commandArgs,
+                };
+                const response = await fetch(url, options);
+                output.responseStatus = response.status;
+                if (response.status >= 400) {
+                  node.status({ fill: "red", shape: "ring", text: "response error" });
+                  output.response = await response.text();
+                  const message = `${baseUrl}: ${output.response}`;
+                  send(output);
+                  doneWithId(node, done, message);
+                  return;
+                }
+                output.response = await response.json();
+                send(output);
+                if (done) done();
+              } catch (err) {
+                node.status({ fill: "red", shape: "ring", text: err.code });
+                if (done) done(err);
+              } finally {
+                if (node.hubitat.delayCommands) {
+                  setTimeout(() => {
+                    node.hubitat.releaseLock();
+                  }, node.hubitat.delayCommands);
+                } else {
+                  node.hubitat.releaseLock();
+                }
+              }
+            }
+          })
+        );
+     } catch (err) {
+        node.error(`Error restoring devices: ${err.message}`, msg);
+        if (done) done(err);
+      }
+    });
+
+    node.on("close", function (removed, done) {
+      try {
+        if (removed) {
+          const flowContext = node.context().flow;
+          const cleanup = configuredDeviceList();
+          if (Array.isArray(cleanup)) {
+            cleanup.forEach(id => flowContext.set(`hubitat_device_state_${id}`, undefined));
+          }
+        }
+        done();
+      } catch (err) {
+        node.error(`Error during close cleanup: ${err.message}`);
+        done();
+      }
+    });
+  }
+
+  RED.nodes.registerType("hubitat restore", HubitatRestoreNode);
+};

--- a/nodes/switch-logic.html
+++ b/nodes/switch-logic.html
@@ -1,0 +1,173 @@
+<script type="text/javascript">
+(function () {
+  let currentRequestId = 0;
+
+  function listSwitchDevices(server, selectedIds, requestId) {
+    const selectMenu = $('#node-input-deviceId');
+    selectMenu.empty();
+
+    $.getJSON('hubitat/devices/all', paramsFromServer(server))
+      .done((res) => {
+        if (requestId !== currentRequestId) return;
+        if (!Array.isArray(res)) {
+          console.warn("hubitat/devices/all returned non-array:", res);
+          return;
+        }
+
+        const deviceId = res.filter((device) => {
+          const hasCapability = Array.isArray(device.capabilities) && device.capabilities.includes('Switch');
+          const hasSwitchAttr = (
+            device.attributes &&
+            device.attributes.switch !== undefined &&
+            device.attributes.switch !== null
+          );
+          return hasCapability || hasSwitchAttr;
+        });
+
+        deviceId.sort((a, b) => {
+          const la = (a.label || a.name || a.id).toString().toLowerCase();
+          const lb = (b.label || b.name || b.id).toString().toLowerCase();
+          return la.localeCompare(lb);
+        });
+
+        deviceId.forEach((device) => {
+          const val = String(device.id);
+          if (selectMenu.find(`option[value="${val}"]`).length === 0) {
+            const option = $('<option>', {
+              value: val,
+              text: device.label || device.name || device.id
+            });
+            if (selectedIds && selectedIds.map(String).includes(val)) {
+              option.prop('selected', true);
+            }
+            selectMenu.append(option);
+          }
+        });
+
+        if (typeof selectMenu.data('initialized') === 'undefined') {
+          selectMenu.data('initialized', true);
+        }
+      })
+      .fail((jqXHR, textStatus, errorThrown) => {
+        console.error("hubitat/devices/all request failed:", textStatus, errorThrown);
+      });
+  }
+
+  RED.nodes.registerType('hubitat switch logic', {
+    category: 'hubitat',
+    color: '#ACE043',
+    defaults: {
+      name: { value: '' },
+      server: { type: 'hubitat config', required: true },
+      deviceId: { value: [] },
+      targetValue: { value: 'on' },
+      mode: { value: 'all' },
+      sendEvents: { value: false }
+    },
+    inputs: 1,
+    outputs: 1,
+    icon: 'font-awesome/fa-undo',
+    label() { return this.name || 'switch logic'; },
+    paletteLabel: 'switch logic',
+
+    oneditprepare() {
+      const node = this;
+      let initialized = false;
+
+      function refreshDeviceList() {
+        const serverId = $('#node-input-server option:selected').val();
+        const server = RED.nodes.node(serverId);
+
+        currentRequestId += 1;
+        const requestId = currentRequestId;
+        $('#node-input-deviceId').empty();
+
+        if (server) {
+          loadCredentials(server).then(() => {
+            listSwitchDevices(server, node.deviceId, requestId);
+            initialized = true; // now user changes trigger updates
+          }).catch(() => {
+            $('#node-input-deviceId').empty();
+          });
+        } else {
+          cleanHubitatDevices();
+        }
+      }
+
+      $('#node-input-server').off('change').on('change', refreshDeviceList);
+      $('#node-input-deviceId').empty();
+      refreshDeviceList();
+
+      // Only update name when device selection changes by user
+      $('#node-input-deviceId').off('.count').on('change.count', function () {
+        if (initialized) updateNameWithCount(node);
+      });
+    },
+
+    oneditsave() {
+      const selected = $('#node-input-deviceId').val() || [];
+      this.deviceId = Array.isArray(selected) ? selected : [selected];
+      this.targetValue = $('#node-input-targetValue').val();
+      this.mode = $('#node-input-mode').val();
+      this.sendEvents = $('#node-input-sendEvents').prop('checked');
+
+      if (this.deviceId.length > 0) {
+        updateNameWithCount(this, { force: true });
+      }
+    }
+  });
+
+  function updateNameWithCount(node, opts) {
+    opts = opts || {};
+    const sel = $('#node-input-deviceId').val();
+    if (!sel || sel.length === 0) return;
+
+    const chosen = Array.isArray(sel) ? sel : [sel];
+    const count = chosen.length;
+
+    let base = $('#node-input-name').val() || (node && node.name) || 'switch logic';
+    base = base.replace(/\s*\(\d+\)$/, '');
+
+    $('#node-input-name').val(base + ' (' + count + ')');
+    return count;
+  }
+})();
+</script>
+
+<script type="text/x-red" data-template-name="hubitat switch logic">
+  <div class="form-row">
+    <label for="node-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-input-name" placeholder="Name">
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-server"><i class="fa fa-globe"></i> Hub</label>
+    <select id="node-input-server"></select>
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-deviceId"><i class="fa fa-toggle-on"></i> Devices</label>
+    <select id="node-input-deviceId" multiple size="8" style="width:100%;"></select>
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-targetValue"><i class="fa fa-bullseye"></i> Target Value</label>
+    <select id="node-input-targetValue">
+      <option value="on">On</option>
+      <option value="off">Off</option>
+    </select>
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-mode"><i class="fa fa-sliders"></i> Mode</label>
+    <select id="node-input-mode">
+      <option value="all">All</option>
+      <option value="any">Any</option>
+    </select>
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-sendEvents"><i class="fa fa-bell"></i> Send events</label>
+    <input type="checkbox" id="node-input-sendEvents">
+  </div>
+</script>

--- a/nodes/switch-logic.html
+++ b/nodes/switch-logic.html
@@ -66,7 +66,7 @@
     },
     inputs: 1,
     outputs: 1,
-    icon: 'font-awesome/fa-undo',
+    icon: 'font-awesome/fa-gears',
     label() { return this.name || 'switch logic'; },
     paletteLabel: 'switch logic',
 

--- a/nodes/switch-logic.js
+++ b/nodes/switch-logic.js
@@ -1,0 +1,199 @@
+/* nodes/switch-logic.js */
+module.exports = function (RED) {
+  function SwitchLogicNode(config) {
+    RED.nodes.createNode(this, config);
+    const node = this;
+
+    node.hubitat = RED.nodes.getNode(config.server);
+    node.name = config.name || '';
+    node.deviceId = Array.isArray(config.deviceId)
+      ? config.deviceId
+      : (config.deviceId ? [config.deviceId] : []);
+    node.targetValue = config.targetValue || 'on';
+    node.mode = config.mode || 'all';
+    // if true, emit an immediate "true" event message on flip to true
+    node.sendEvents = !!config.sendEvents;
+
+    // runtime state
+    const deviceStates = {};   // deviceId -> latest value (e.g. "on" / "off")
+    let logicState = null;     // true/false
+    let lastFlip = null;       // Date of last flip
+
+    const deviceListeners = {}; // deviceId -> callback
+    let systemStartCallback = null;
+
+    function normalizeAttributeValue(device, attrName) {
+      const attrs = device && device.attributes;
+      if (!attrs) return undefined;
+
+      if (Array.isArray(attrs)) {
+        const found = attrs.find(a => a && (a.name === attrName));
+        if (!found) return undefined;
+        return found.value ?? found.currentValue ?? found;
+      }
+
+      const attr = attrs[attrName];
+      if (attr === undefined) return undefined;
+      if (attr && typeof attr === 'object') {
+        return attr.value ?? attr.currentValue ?? attr;
+      }
+      return attr;
+    }
+
+    async function initializeFromCache() {
+      if (!node.hubitat) return;
+      try {
+        if (typeof node.hubitat.devicesFetcher === 'function') {
+          await node.hubitat.devicesFetcher();
+        }
+      } catch (err) {
+        node.warn(`Unable to fetch devices cache: ${err && err.message ? err.message : err}`);
+      }
+
+      node.deviceId.forEach((id) => {
+        const dev = node.hubitat && node.hubitat.devices && node.hubitat.devices[id];
+        if (dev) {
+          const val = normalizeAttributeValue(dev, 'switch');
+          if (val !== undefined) {
+            deviceStates[id] = val;
+          }
+        }
+      });
+
+      // set initial aggregated logic state (don't consider this a flip)
+      const newState = computeLogicState();
+      logicState = newState;
+      updateStatus();
+    }
+
+    function computeLogicState() {
+      if (!node.deviceId || node.deviceId.length === 0) return false;
+      const desired = node.targetValue;
+      const values = node.deviceId.map(id => deviceStates[id]);
+      if (node.mode === 'all') {
+        return values.length > 0 && values.every(v => v === desired);
+      } else {
+        return values.some(v => v === desired);
+      }
+    }
+
+function updateStatus() {
+  let stateText;
+  if (logicState === null) {
+    stateText = 'waiting for events';
+  } else {
+    const stamp = lastFlip ? lastFlip.toLocaleString() : '–';
+    stateText = `${logicState ? 'TRUE' : 'FALSE'} ${stamp}`;
+  }
+  node.status({
+    fill: logicState ? 'green' : 'grey',
+    shape: node.sendEvents ? 'dot' : 'ring',
+    text: stateText
+  });
+}
+
+
+    function handleDeviceEvent(event) {
+      if (!event || !event.deviceId) return;
+      const deviceId = String(event.deviceId);
+      if (event.name !== 'switch') return;
+
+      const value = event.value;
+      deviceStates[deviceId] = value;
+
+      const newState = computeLogicState();
+      if (newState !== logicState) {
+        logicState = newState;
+        lastFlip = new Date();
+        updateStatus();
+        if (logicState && node.sendEvents) {
+          try {
+            node.send({ payload: true });
+          } catch (err) {
+            node.warn(err && err.message ? err.message : err);
+          }
+        }
+      } else {
+        updateStatus();
+      }
+    }
+
+    function attachListeners() {
+      if (!node.hubitat || !node.hubitat.hubitatEvent) return;
+
+      node.deviceId.forEach((id) => {
+        const deviceId = String(id);
+        const callback = (event) => {
+          if (event && (event.deviceId === undefined) && event.id) {
+            event.deviceId = event.id;
+          }
+          handleDeviceEvent(event);
+        };
+
+        const eventName = `device.${deviceId}`;
+        deviceListeners[deviceId] = { eventName, callback };
+        node.hubitat.hubitatEvent.on(eventName, callback);
+      });
+
+      systemStartCallback = async () => {
+        await initializeFromCache();
+      };
+      node.hubitat.hubitatEvent.on('systemStart', systemStartCallback);
+    }
+
+    function detachListeners() {
+      if (!node.hubitat || !node.hubitat.hubitatEvent) return;
+      Object.keys(deviceListeners).forEach((deviceId) => {
+        const { eventName, callback } = deviceListeners[deviceId] || {};
+        if (eventName && callback) {
+          node.hubitat.hubitatEvent.removeListener(eventName, callback);
+        }
+      });
+      Object.keys(deviceListeners).forEach(k => delete deviceListeners[k]);
+      if (systemStartCallback) {
+        node.hubitat.hubitatEvent.removeListener('systemStart', systemStartCallback);
+        systemStartCallback = null;
+      }
+    }
+
+    (async () => {
+      if (!node.hubitat) {
+        node.error('Hubitat server not configured');
+        updateStatus();
+        return;
+      }
+      try {
+        await initializeFromCache();
+      } catch (err) {
+        node.warn(`Initialization error: ${err && err.message ? err.message : err}`);
+      }
+      attachListeners();
+    })();
+
+    node.on('input', (msg, send, done) => {
+      try {
+        if (computeLogicState()) {
+          send(msg);
+        } else {
+          send(null);
+        }
+      } catch (err) {
+        node.error(err && err.message ? err.message : err);
+      }
+      if (done) done();
+    });
+
+    node.on('close', (removed, done) => {
+      try {
+        detachListeners();
+      } catch (err) {
+        node.warn(`Error detaching listeners: ${err && err.message ? err.message : err}`);
+      }
+      if (done) done();
+    });
+
+    updateStatus();
+  }
+
+  RED.nodes.registerType('hubitat switch logic', SwitchLogicNode);
+};

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
       "request": "nodes/request.js",
       "switch-logic": "nodes/switch-logic.js",
       "capture": "nodes/capture.js",
-      "restore": "nodes/restore.js"
+      "restore": "nodes/restore.js",
+      "logic": "nodes/logic.js"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
       "location": "nodes/location.js",
       "mode": "nodes/mode.js",
       "mode-setter": "nodes/mode-setter.js",
-      "request": "nodes/request.js"
+      "request": "nodes/request.js",
+      "switch-logic": "nodes/switch-logic.js",
+      "capture": "nodes/capture.js",
+      "restore": "nodes/restore.js"
     }
   },
   "engines": {


### PR DESCRIPTION
This pull request is intended to add two features to the Node Red Nodes for Hubitat.  These were written with the help of chatGPT, so I'll apologize in advance for the syntax it produced.  It went through many, many iterations, so there's a good chance there's still some redundant code present.  I'm writing this PR description myself, so whatever errors are in this text are all on me.

One challenge that I encountered was that the existing repo didn't appear to expose a method to get devices with all attributes, and that was needed to filter for only switch devices.  There may be a better method, or at least a method more consistent with the structure of the repo, to execute the call for getting the device list.  I tried to keep everything self-contained in these nodes but it may be cleaner to move some functions into a common/global context.

The switch-logic node allows the user to select one or more devices that have the 'switch' attribute.  They can select a target value of 'on' or 'off' and a mode of 'all' or 'any'.  They can also select 'Send Events'.  The node will act as a logic gate and only pass messages when it evaluates as true.  If 'Send Events' is selected, it will emit a message when it turns true.  It never emits a message when false or turning false.

To do this without this node the user would have use a Device node and then a switch node to evaluate the on/off status of the device, and would have to chain together multiple Device/switch nodes to evaluate multiple devices.  When trying to do that with 'Send events' this can get quite complicated if you're trying to evaluate for all devices being on or off.   

With apologies for probably stating the obvious, examples of uses for this node:
- Only pass the message if all outside lights are off 
  - select all outside lights, target value "off", mode "all", send events: false
- When any kitchen light turns on, turn on all kitchen lights 
  - select all kitchen lights, target value "on", mode "any", send events: true -- wire to a command node to turn on kitchen lights

The node is useful even with a single device selected since it combines the device node and the switch node into a single entity. 

The node status uses a solid or dotted icon consistent with the other nodes to indicate if 'Send Events' is selected.  The status shows a green circle and 'TRUE' or a gray circle and 'FALSE' plus the date and time it last flipped states.  

When editing the node, the total number of devices selected is always appended to the node name, so if you select 4 devices the default name would be "switch logic (4)".  If you named it "All kitchen lights" it would be named "All kitchen lights (4)".  This numbering behavior is also present in the other nodes.

The second thing added is a pair of nodes to perform a device capture/restore function.  Like the switch-logic, the user is presented with a multi-select of all devices with a switch attribute.  When triggered by an incoming message, the capture node will store the state of the selected devices in the flow context and will emit a message containing an array with the deviceId and name of each device that was captured.  It also stores its own unique nodeID as the owner of that context data.  If the node is edited or removed, it will clean up all context data that it owns to ensure stored devices are not orphaned in the context data. 

The restore node has a similar interface to the capture node.  When it is triggered by an incoming message, it emits one message for each device that was sent a command.  These messages look like the output of the repo's existing Command node.  

If the user has selected a device that has no stored state, it will emit a message that says "No saved state for {deviceId}" for each device with no stored state.  

The restore node clears the stored state for each device it restores.   The capture and restore should work for switches, dimmers, and color bulbs.  The code looks at which attributes are present to determine what command to send when restoring a device.

If one capture node captures a device and then another capture node captures the same device, the second state will overwrite the first and the owner will be the most recent node to store a state for that device.  The most recent state will be restored by the first restore node that tries to restore that device.  

I've started wiring these nodes into my home automation flows and they're letting me clean up a lot of 'spaghetti' flows that were having to use many nodes to accomplish what these can do in a single node.  